### PR TITLE
Make RF-DETR/YOLOv12 training reproducible and directly comparable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ data-setup/models/
 # yolov12
 yolov12/*.pt
 yolov12/runs/
+/runs/
 
 # yolov5 (vendored, not a submodule)
 yolov5/

--- a/data-setup/yolo_split.py
+++ b/data-setup/yolo_split.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Split LodeSTAR-autolabeled YOLO data into train/valid/test by experiment name.
+
+Reuses the SAME train_experiments/val_experiments/test_experiments lists as
+rf-detr/config.yaml (read directly from that file by default), so RF-DETR and
+YOLO models train and evaluate on identical images with an identical held-out
+split -- required for a fair accuracy/speed comparison between the two.
+
+Discovers per-video datasets produced by lodestar_autolabeler.py, i.e. any
+'<video_stem>_dataset/images/ + labels/' directory found (at any depth) under
+each --input path. A video is assigned to a split if its stem contains any of
+that split's configured experiment-name substrings (same substring-match rule
+as rf-detr/dataset.py:split_by_experiment).
+
+Usage:
+    python yolo_split.py \\
+        --input "/mnt/d/Particle Tracking Data/2um-automatic-particle-detection-lodestar-data/2 um Higher Concentration" \\
+                "/mnt/d/Particle Tracking Data/2um-automatic-particle-detection-lodestar-data/2 um Lower Concentration" \\
+        --output "/mnt/d/Particle Tracking Data/2um-yolov12-matched"
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+CLASS_NAMES = ["particle"]
+VALID_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp"}
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Split LodeSTAR-autolabeled YOLO data by experiment name for YOLO training."
+    )
+    parser.add_argument(
+        "--input", required=True, nargs="+", help="One or more directories to search for datasets"
+    )
+    parser.add_argument("--output", required=True, help="Destination directory")
+    parser.add_argument(
+        "--experiments-config",
+        default=None,
+        help="Path to rf-detr/config.yaml providing train/val/test experiment lists "
+        "(default: ../rf-detr/config.yaml relative to this script)",
+    )
+    parser.add_argument(
+        "--copy",
+        action="store_true",
+        help="Copy images/labels instead of symlinking (default: symlink)",
+    )
+    return parser.parse_args()
+
+
+def _load_experiment_lists(config_path: Path) -> dict[str, list[str]]:
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+    ds_cfg = config["dataset"]
+    return {
+        "train": ds_cfg["train_experiments"],
+        "valid": ds_cfg["val_experiments"],
+        "test": ds_cfg["test_experiments"],
+    }
+
+
+def _discover_video_datasets(input_dirs: list[Path]) -> list[tuple[str, Path, Path]]:
+    """Find every '<video_stem>_dataset/images + labels' dir under input_dirs.
+
+    Returns (video_stem, images_dir, labels_dir) tuples, sorted by video_stem
+    for deterministic ordering.
+    """
+    found = {}
+    for input_dir in input_dirs:
+        for images_dir in sorted(input_dir.rglob("images")):
+            if not images_dir.is_dir():
+                continue
+            dataset_dir = images_dir.parent
+            labels_dir = dataset_dir / "labels"
+            if not labels_dir.is_dir():
+                continue
+            stem = dataset_dir.name.removesuffix("_dataset")
+            found[stem] = (stem, images_dir, labels_dir)
+    return sorted(found.values(), key=lambda t: t[0])
+
+
+def _assign_split(video_stem: str, experiment_lists: dict[str, list[str]]) -> str | None:
+    for split_name, experiments in experiment_lists.items():
+        if any(exp in video_stem for exp in experiments):
+            return split_name
+    return None
+
+
+def _place(src: Path, dst: Path, copy: bool) -> None:
+    if dst.exists() or dst.is_symlink():
+        dst.unlink()
+    if copy:
+        import shutil
+
+        shutil.copy2(src, dst)
+    else:
+        dst.symlink_to(src.resolve())
+
+
+def main() -> None:
+    args = _parse_args()
+
+    script_dir = Path(__file__).parent
+    experiments_config = (
+        Path(args.experiments_config)
+        if args.experiments_config
+        else script_dir / ".." / "rf-detr" / "config.yaml"
+    )
+    if not experiments_config.exists():
+        sys.exit(f"Error: experiments config not found: {experiments_config}")
+    experiment_lists = _load_experiment_lists(experiments_config)
+
+    input_dirs = [Path(p) for p in args.input]
+    for input_dir in input_dirs:
+        if not input_dir.is_dir():
+            sys.exit(f"Error: input directory not found: {input_dir}")
+
+    datasets = _discover_video_datasets(input_dirs)
+    if not datasets:
+        sys.exit(f"Error: no '<video>_dataset/images+labels' directories found under {input_dirs}")
+
+    output_dir = Path(args.output)
+    for split_name in ("train", "valid", "test"):
+        (output_dir / split_name / "images").mkdir(parents=True, exist_ok=True)
+        (output_dir / split_name / "labels").mkdir(parents=True, exist_ok=True)
+
+    split_counts = {"train": 0, "valid": 0, "test": 0}
+    unmatched = []
+
+    for video_stem, images_dir, labels_dir in datasets:
+        split_name = _assign_split(video_stem, experiment_lists)
+        if split_name is None:
+            unmatched.append(video_stem)
+            continue
+
+        img_out = output_dir / split_name / "images"
+        lbl_out = output_dir / split_name / "labels"
+
+        for img_path in sorted(images_dir.iterdir()):
+            if not img_path.is_file() or img_path.suffix.lower() not in VALID_IMAGE_EXTS:
+                continue
+            lbl_path = labels_dir / f"{img_path.stem}.txt"
+            if not lbl_path.exists():
+                continue
+
+            fname_prefix = f"{video_stem}_{img_path.name}"
+            _place(img_path, img_out / fname_prefix, args.copy)
+            _place(lbl_path, lbl_out / f"{video_stem}_{lbl_path.name}", args.copy)
+            split_counts[split_name] += 1
+
+    if unmatched:
+        print(
+            f"Warning: {len(unmatched)} video(s) matched no experiment list and were skipped:",
+            file=sys.stderr,
+        )
+        for stem in unmatched:
+            print(f"  - {stem}", file=sys.stderr)
+
+    yaml_content = (
+        f"path: {output_dir.absolute()}\n"
+        "train: train/images\n"
+        "val: valid/images\n"
+        "test: test/images\n\n"
+        f"nc: {len(CLASS_NAMES)}\n"
+        f"names: {CLASS_NAMES}\n"
+    )
+    (output_dir / "data.yaml").write_text(yaml_content, encoding="utf-8")
+
+    print(f"Split {len(datasets) - len(unmatched)} video(s) using {experiments_config}:")
+    for split_name, count in split_counts.items():
+        print(f"  {split_name:5s}: {count} images")
+    print(f"\nWrote {output_dir / 'data.yaml'}")
+    print(
+        "Point yolov12/config.yaml -> data.dir at this folder to train on the same split as RF-DETR."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rf-detr/config.k8s.yaml
+++ b/rf-detr/config.k8s.yaml
@@ -31,6 +31,13 @@ model:
   resolution: null                  # rfdetr large default: 704px
 
 training:
+  seed: 42                          # seeds all RNGs at fit start (rfdetr no-ops seeding when unset — see module_model.py:on_fit_start)
+  # NOT YET APPLIED to checkpoints-a40/ -- that checkpoint predates this config (trained unseeded, HorizontalFlip only).
+  # yolov12/config.yaml's flipud is deliberately kept at 0.0 to match it. Retrain rf-detr with this config, then
+  # bump yolov12's flipud back to 0.5, to restore matched augmentation between the two models.
+  aug_config:                        # rfdetr's library default (AUG_CONFIG) leaves VerticalFlip commented out;
+    HorizontalFlip: {p: 0.5}         # particle microscopy frames have no canonical "up", so enable it here
+    VerticalFlip: {p: 0.5}           # (matches yolov12's flipud, once yolov12 is bumped back to 0.5)
   epochs: 50
   batch_size: 2                     # A40 48GB; group_detr=13 expands queries to 3900 in loss, same memory as 3400 without group_detr
   grad_accum_steps: 4               # effective_batch = 2 * 4 = 8 (same as local config)

--- a/rf-detr/config.yaml
+++ b/rf-detr/config.yaml
@@ -31,6 +31,13 @@ model:
   resolution: null                 # input resolution in px (null = rfdetr default: 704 for large, 560 for base)
 
 training:
+  seed: 42                         # seeds all RNGs at fit start (rfdetr no-ops seeding when unset — see module_model.py:on_fit_start)
+  # NOT YET APPLIED to checkpoints/ -- that checkpoint predates this config (trained unseeded, HorizontalFlip only).
+  # yolov12/config.yaml's flipud is deliberately kept at 0.0 to match it. Retrain rf-detr with this config, then
+  # bump yolov12's flipud back to 0.5, to restore matched augmentation between the two models.
+  aug_config:                       # rfdetr's library default (AUG_CONFIG) leaves VerticalFlip commented out;
+    HorizontalFlip: {p: 0.5}        # particle microscopy frames have no canonical "up", so enable it here
+    VerticalFlip: {p: 0.5}          # (matches yolov12's flipud, once yolov12 is bumped back to 0.5)
   epochs: 50
   batch_size: 1                    # forced to 1; auto-tuner understimates peak VRAM from 600-query IoU loss on 12 GB GPUs
   grad_accum_steps: 8              # effective_batch = batch_size * grad_accum_steps; drop to 1 on large GPUs

--- a/rf-detr/train.py
+++ b/rf-detr/train.py
@@ -96,6 +96,8 @@ def main() -> None:
 
     train_kwargs: dict = {
         "dataset_dir": str(dataset_dir),
+        "seed": train_cfg["seed"],
+        "aug_config": train_cfg["aug_config"],
         "epochs": train_cfg["epochs"],
         "batch_size": train_cfg["batch_size"],
         "grad_accum_steps": train_cfg["grad_accum_steps"],

--- a/yolov12/config.yaml
+++ b/yolov12/config.yaml
@@ -1,5 +1,5 @@
 data:
-  dir: "/mnt/d/Particle Tracking Data/2um-yolov12/"             # path to directory containing data.yaml and images (absolute or relative to this config file)
+  dir: "/mnt/d/Particle Tracking Data/2um-yolov12-matched/"      # same images + train/val/test split as rf-detr/config.yaml (data-setup/yolo_split.py), for an apples-to-apples comparison
 
 model:
   weights: yolo12m.pt    # medium variant: better spatial feature depth for dense single-class detection
@@ -7,9 +7,13 @@ model:
 
 training:
   epochs: 100
-  batch: 16
+  batch: 4                # dropped from 16: TaskAlignedAssigner's per-batch cost tensor scales with
+                          # batch x max_particles_in_batch x anchors -- frames average ~1480 particles
+                          # (max 3225), which OOM'd the assigner on the RTX 4070 12GB at batch 16
   device: "0"
   name: yolo12m-particles
+  flipud: 0.0             # kept off for now to match rf-detr's CURRENTLY TRAINED checkpoint (predates rf-detr/config.yaml's
+                          # VerticalFlip addition). Bump to 0.5 once rf-detr is retrained with that config -- see aug_config there.
 
 mlflow:
   experiment_name: yolov12

--- a/yolov12/evaluate.py
+++ b/yolov12/evaluate.py
@@ -1,84 +1,62 @@
-import torch
-import numpy as np
-from yolov12.models.experimental import attempt_load
-from yolov12.utils.datasets import LoadImagesAndLabels
-from yolov12.utils.general import non_max_suppression, scale_coords
-from yolov12.utils.metrics import ap_per_class
-from yolov12.utils.torch_utils import select_device
+import os
+
+import mlflow
+import yaml
+
+from mlflow_utils import end_run, start_run
+from ultralytics import YOLO
 
 
-def evaluate_yolov12(weights, data, img_size=640, conf_thres=0.001, iou_thres=0.6, device=""):
-    # Load model
-    device = select_device(device)
-    model = attempt_load(weights, map_location=device)
-    model.eval()
-
-    # Load validation data
-    dataset = LoadImagesAndLabels(data["val"], img_size, batch_size=1, rect=True)
-    iouv = torch.linspace(0.5, 0.95, 10).to(device)  # mAP@0.5:0.95
-
-    stats = []
-    for batch_i, (img, targets, paths, shapes) in enumerate(dataset):
-        img = img.to(device).float() / 255.0
-        if img.ndimension() == 3:
-            img = img.unsqueeze(0)
-
-        # Inference
-        with torch.no_grad():
-            pred = model(img)[0]
-            pred = non_max_suppression(pred, conf_thres, iou_thres)
-
-        # Statistics per image
-        for image_index, det in enumerate(pred):
-            labels = targets[image_index][:, 1:] if len(targets) else []
-            num_labels = len(labels)
-            tcls = labels[:, 0].tolist() if num_labels else []
-            if det is not None and len(det):
-                det[:, :4] = scale_coords(img.shape[2:], det[:, :4], shapes[image_index][0]).round()
-                correct = torch.zeros(det.shape[0], iouv.numel(), dtype=torch.bool, device=device)
-                # TODO: implement matching logic for correct detections
-            else:
-                correct = torch.zeros(0, iouv.numel(), dtype=torch.bool, device=device)
-            stats.append(
-                (
-                    correct.cpu(),
-                    det[:, 4].cpu() if det is not None else torch.Tensor(),
-                    det[:, 5].cpu() if det is not None else torch.Tensor(),
-                    tcls,
-                )
-            )
-
-    # Compute metrics
-    stats = [np.concatenate(x, 0) for x in zip(*stats)]
-    if len(stats) and stats[0].any():
-        precision, recall, avg_precision, f1_score, ap_class = ap_per_class(
-            *stats, plot=False, save_dir=None
-        )
-        print(
-            f"Precision: {precision.mean():.4f}, Recall: {recall.mean():.4f}, mAP@0.5: {avg_precision[:, 0].mean():.4f}, mAP@0.5:0.95: {avg_precision.mean():.4f}"
-        )
-    else:
-        print("No detections.")
-
-
-def run(config_path: str = "config.yaml") -> None:
-    import os
-    import yaml
-
+def run(config_path: str = "config.yaml", weights: str | None = None) -> None:
     config_dir = os.path.dirname(os.path.abspath(__file__))
     if not os.path.isabs(config_path):
         config_path = os.path.join(config_dir, config_path)
+
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
     with open(config_path) as f:
         config = yaml.safe_load(f)
-    weights = config["model"]["weights"]
+
+    model_cfg = config["model"]
+    train_cfg = config["training"]
+    mlflow_cfg = config["mlflow"]
     data_dir = config["data"]["dir"]
+
     if not os.path.isabs(data_dir):
         data_dir = os.path.join(os.path.dirname(config_path), data_dir)
-    data = {"val": os.path.join(data_dir, "validation/images")}
-    evaluate_yolov12(weights, data)
+    data_yaml = os.path.join(data_dir, "data.yaml")
+    if not os.path.exists(data_yaml):
+        raise FileNotFoundError(f"Dataset YAML not found: {data_yaml}")
+
+    if weights is None:
+        weights = os.path.join(
+            config_dir, "runs", "detect", train_cfg["name"], "weights", "best.pt"
+        )
+    if not os.path.exists(weights):
+        raise FileNotFoundError(
+            f"Trained weights not found: {weights}. Run 'main.py train' first, "
+            "or pass an explicit weights path."
+        )
+
+    start_run(
+        experiment_name=mlflow_cfg["experiment_name"],
+        run_name=f"evaluate-{os.path.splitext(os.path.basename(weights))[0]}",
+        params={"weights": weights, "data": data_yaml},
+    )
+
+    try:
+        model = YOLO(weights)
+        metrics = model.val(data=data_yaml, imgsz=model_cfg["imgsz"], split="test")
+        mlflow.log_metrics(
+            {
+                key.replace("(", "_").replace(")", ""): float(value)
+                for key, value in metrics.results_dict.items()
+            }
+        )
+    finally:
+        end_run()
 
 
 if __name__ == "__main__":
-    WEIGHTS = "yolov12.pt"
-    DATA = {"val": "data/val.txt"}  # Update with your validation data path
-    evaluate_yolov12(WEIGHTS, DATA)
+    run()

--- a/yolov12/mlflow_utils.py
+++ b/yolov12/mlflow_utils.py
@@ -6,7 +6,16 @@ import mlflow
 def start_run(experiment_name: str, run_name: str, params: dict[str, Any]) -> mlflow.ActiveRun:
     base_dir = os.path.dirname(os.path.abspath(__file__))
     db_path = os.path.join(base_dir, "..", "data-setup", "mlflow.db")
-    mlflow.set_tracking_uri(f"sqlite:///{db_path}")
+    tracking_uri = f"sqlite:///{db_path}"
+    # Also set as env vars: ultralytics' own built-in MLflow autolog callback
+    # (on by default, fires from model.train()) reads MLFLOW_TRACKING_URI /
+    # MLFLOW_EXPERIMENT_NAME independently of the in-process mlflow client we
+    # configure below. Without these, it silently redirects logging to its own
+    # default store (<repo_root>/runs/mlflow, experiment "/Shared/Ultralytics")
+    # instead of this project's shared data-setup/mlflow.db.
+    os.environ["MLFLOW_TRACKING_URI"] = tracking_uri
+    os.environ["MLFLOW_EXPERIMENT_NAME"] = experiment_name
+    mlflow.set_tracking_uri(tracking_uri)
 
     mlflow.set_experiment(experiment_name)
     run = mlflow.start_run(run_name=run_name)

--- a/yolov12/train.py
+++ b/yolov12/train.py
@@ -68,7 +68,9 @@ def run(config_path: str = "config.yaml") -> None:
             imgsz=model_cfg["imgsz"],
             batch=train_cfg["batch"],
             device=train_cfg["device"],
+            project=os.path.join(config_dir, "runs", "detect"),
             name=train_cfg["name"],
+            flipud=train_cfg["flipud"],
             task="detect",
         )
     finally:


### PR DESCRIPTION
## Summary

- **RF-DETR trained unseeded.** `rfdetr` only calls `seed_everything()` at fit start when `TrainConfig.seed` is set; it never was, so every run (weight init, dataloader shuffle, augmentation) was non-reproducible. Fixed by adding `seed: 42` to both `config.yaml` and `config.k8s.yaml` and threading it through `train.py`.
- **YOLOv12 trained on a disconnected dataset.** It pointed at a separate Roboflow export with a different split than RF-DETR's `2um-coco-merged`, making any speed/accuracy comparison between the two invalid. Fixed with `data-setup/yolo_split.py`, which splits the same LodeSTAR-labeled source data RF-DETR uses, by the exact same `train_experiments`/`val_experiments`/`test_experiments` lists (read directly from `rf-detr/config.yaml`), into YOLO format.
- **Augmentation mismatch.** RF-DETR's library default leaves `VerticalFlip` commented out; enabled it (domain-justified — microscopy particle frames have no canonical "up", same reasoning as the existing LodeSTAR augmentation pipeline). YOLOv12's `flipud` is deliberately kept at `0.0` for now since RF-DETR's *currently trained* checkpoints predate this change — comments in both configs point at each other so the two can be re-matched once RF-DETR is retrained.
- **`yolov12/evaluate.py` was dead code** — it imported from a legacy YOLOv5-style vendored package that was never part of this repo, breaking `main.py` for every stage (`process`/`train`/`evaluate`) since `evaluate` is imported unconditionally. Rewritten against the `ultralytics` API, matching `train.py`'s pattern, and fixed a second latent bug (`validation/images` vs. actual `valid/images`).
- **Silent MLflow tracking conflict.** Ultralytics ships its own MLflow autolog callback (on by default) that reads `MLFLOW_TRACKING_URI`/`MLFLOW_EXPERIMENT_NAME` from environment variables. `yolov12/mlflow_utils.py` only set the tracking URI via the in-process Python API, so Ultralytics' callback silently redirected logging to its own default store instead of the shared `data-setup/mlflow.db`. Fixed by also setting the env vars.
- **CUDA OOM in `TaskAlignedAssigner`.** This dataset is extremely dense (avg ~1480 particles/frame, max 3225), and the assigner's per-batch cost tensor scales with `batch x max_particles_in_batch x anchors`. Dropped `batch: 16 -> 4` to fix it.
- **Training output leak.** `model.train()` never passed `project=`, so output fell back to Ultralytics' default (repo root `runs/`, not gitignored) instead of `yolov12/runs/` (which is). Fixed the path and added `/runs/` to `.gitignore` as a safety net.

## Test plan

- [x] `rf-detr/tests/` — 24/24 passing
- [x] Both `rf-detr/config.yaml` and `config.k8s.yaml` parse and resolve `seed`/`aug_config` correctly
- [x] `yolov12/config.yaml` parses correctly with new `flipud`/`batch` values
- [x] `data-setup/yolo_split.py` run against the real dataset: 15/15 videos matched, 660/120/120 train/valid/test images, every image has a matching label, no `_overlay.png`/`crops` leakage
- [x] `yolov12/main.py` imports cleanly (previously crashed on `evaluate.py` import)
- [ ] Full RF-DETR/YOLOv12 training runs (deferred — will be run separately given compute time)