### PR TITLE
fix(ci): exclude deleted files from lint workflow's changed-files diff

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             # PR: only lint changed files
-            FILES=$(git diff --name-only origin/${{ github.base_ref }} -- '*.py' | tr '\n' ' ')
+            FILES=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }} -- '*.py' | tr '\n' ' ')
             echo "scope=PR (changed files only)" >> $GITHUB_OUTPUT
           else
             # Push or manual: lint all tracked files


### PR DESCRIPTION
## Summary
- \`.github/workflows/pylint.yml\`'s "Determine files to lint" step for `pull_request`-triggered runs computes its file list via \`git diff --name-only origin/${{ github.base_ref }} -- '*.py'\`, which includes files the diff *deletes*, not just adds/modifies.
- `black`/`pylint` can't check a path that no longer exists, so any PR that deletes a `.py` file makes this lint job fail with `Invalid value for 'SRC ...': Path '...' does not exist.` -- unrelated to whether the deleted file's removal was itself correct.
- Adds `--diff-filter=d` to exclude deletions from the diff. General fix, not tied to any specific PR's deletions.

## Discovery context
Found while shipping PR #45 (removes several dead `verification/` files as part of a `render_strategy: deeptrack` cleanup) -- that PR's own fix for this bug can't take effect on its own `pull_request`-triggered check, since GitHub Actions reads the workflow YAML for `pull_request` events from the base branch, not the PR branch. Landing this here first unblocks that check structurally.

## Testing
Verified locally: \`git diff --name-only --diff-filter=d origin/main -- '*.py'\` against PR #45's branch correctly excludes its 3 deleted files, and \`black --check\` passes against the resulting list.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required -- this only changes a CI workflow's file-selection logic, with no runtime/production impact.