### PR TITLE
feat: add ByteTrack tracking support alongside trackpy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Has project context (has collective learning of all agents working on the projec
 
 - The repo is a chain of independent `uv`-managed Python subprojects, each with its own `pyproject.toml`/`.venv`: `data-setup/` (LodeSTAR auto-labeling), `rf-detr/` (detector training), `particle-tracking/` (tracking pipeline), `verification/` (end-to-end validation harness), plus `lammps-scripts/` (plain-Python simulation, no venv needed). See README.md#repository-structure for the full tree.
 - `detectors-common/` is a shared local package (editable path dependency) with detector-loading/tiling/config-merge code consumed by both `rf-detr/` and `particle-tracking/`. Put cross-cutting detector logic there instead of duplicating it in both subprojects.
-- `trackers-common/` is a second shared local package (editable path dependency), consumed by `particle-tracking/`, `verification/`, and `rf-detr/`, with trackpy-linking and per-model tracking-tuning primitives. See `trackers-common/README.md` for its scope boundary against `detectors-common` and its re-export convention.
+- `trackers-common/` is a second shared local package (editable path dependency), consumed by `particle-tracking/`, `verification/`, and `rf-detr/`, with trackpy-linking, ByteTrack-tracking, and per-model tracking-tuning primitives. See `trackers-common/README.md` for its scope boundary against `detectors-common` and its re-export convention.
 - `particle-tracking/` intentionally excludes the `rfdetr` package from its own dependencies and loads it at runtime from `rf-detr/.venv` instead, to avoid CUDA build conflicts (see the comment above `[[tool.uv.index]]` in `particle-tracking/pyproject.toml`). Don't "fix" this by adding `rfdetr` back as a direct dependency.
 
 ## Vocab
@@ -27,7 +27,7 @@ Domain terms (PSF, MOTA/IDF1, render strategies, box_size vs. psf_sigma_px, etc.
 
 - Run tests from inside each subproject: `cd <subproject> && uv run pytest tests/ -v`. There is no root-level test command that covers everything.
 - CI (`.github/workflows/pylint.yml`) runs each of `rf-detr/`, `particle-tracking/`, `verification/`, `detectors-common/`, `data-setup/`, and `trackers-common/`'s test suites on every push and PR, blocking on failure. `yolov12/` has no `tests/` directory yet. `lammps-scripts/test/` contains only JSON fixtures, not a runnable pytest suite, and `lammps-scripts/` has its own `.venv/` despite earlier notes here claiming otherwise. Black is also blocking; pylint stays non-blocking until it installs each subproject's own dependencies instead of a shared root-level set (it currently reports import-resolution noise it can't otherwise avoid).
-- `verification/benchmark.py`'s MOTA/IDF1 tracking metrics run a standalone `trackpy` linker, not the production `particle-tracking/track.py` linker (documented in `verification/README.md`). Don't treat those numbers as production tracking accuracy without a separate comparison against real `track.py` output.
+- `verification/benchmark.py`'s MOTA/IDF1 tracking metrics (`--tracker trackpy|bytetrack`) link detections with the same `trackers_common` implementation `particle-tracking/track.py`'s production tracker uses; see `verification/README.md` for what still differs (config overrides, per-tracker tuning coverage) before treating those numbers as production tracking accuracy.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ molecular-dynamics-simulation/
 │   ├── runs/detect/train/weights/best.pt
 │   └── processed_data/      # Train/validation image splits
 ├── detectors-common/        # Shared detector-loading/tiling/config-merge package (rf-detr/, particle-tracking/)
-├── trackers-common/         # Shared trackpy-linking/tracking-tuning package (particle-tracking/, verification/, rf-detr/)
+├── trackers-common/         # Shared trackpy-linking/ByteTrack-tracking/tracking-tuning package (particle-tracking/, verification/, rf-detr/)
 ├── dataset-profiles/        # Per-dataset scale profiles (size_px/spacing_px) detection/tracking params derive from
 ├── particle-tracking/       # Particle tracking pipeline
 │   ├── track.py             # Unified tracker (RF-DETR, YOLOv12, or LodeSTAR)

--- a/detectors-common/README.md
+++ b/detectors-common/README.md
@@ -5,10 +5,12 @@ LodeSTAR, and YOLOv12, extracted from `particle-tracking/track.py` and
 `verification/benchmark.py` to stop the two from drifting against each other
 (see `docs/plans/2026-07-17-001-refactor-consolidate-verification-particle-tracking-plan.md`).
 
-Installed as a local `uv` editable path dependency by `rf-detr/` and
-`particle-tracking/`. `verification/` never installs it directly — it only
-becomes reachable after `verification/benchmark.py`'s existing cross-venv
-re-exec lands in one of the other two venvs.
+Installed as a local `uv` editable path dependency by `rf-detr/`,
+`particle-tracking/`, and `verification/` (the last of these added later, for
+`dataset_profile`/`scale_derivation` support — `verification/benchmark.py`'s
+own consumers still use the lazy-import-per-wrapper pattern below rather than
+importing at module scope, since its venv can never safely hold
+`torch`/`rfdetr`).
 
 ## Conventions
 
@@ -26,13 +28,17 @@ document is long gone by the time you're reading this:
    (`monkeypatch.setattr(track, "get_rfdetr_model", ...)`,
    `mock.patch.object(benchmark, "get_lodestar_model", ...)`) keep working
    unchanged.
-2. **This package stays scoped to detector loading, tiling, and config-merge
-   primitives only.** Tracking-linkage logic, MLflow helpers, or other
-   pipeline-stage code belongs elsewhere, even once a shared package exists
-   to make it tempting to add "just one more thing" here. Keeping this
-   package free of `torch`/`rfdetr`/`deeplay` as its own dependencies (they
-   stay lazy, function-local imports) is what makes it safe to install into
-   any CUDA-sensitive venv — a heavier package would undermine that.
+2. **This package stays scoped to detector loading, tiling, config-merge, and
+   detection-side geometry primitives only** (e.g. `point_to_box.py`'s
+   point-to-box synthesis — a raw-detection-output concern, consumed before
+   any tracker sees the result; see that module's own docstring for why it
+   lives here and not in `trackers-common`). Tracking-linkage logic, MLflow
+   helpers, or other pipeline-stage code belongs elsewhere, even once a
+   shared package exists to make it tempting to add "just one more thing"
+   here. Keeping this package free of `torch`/`rfdetr`/`deeplay` as its own
+   dependencies (they stay lazy, function-local imports) is what makes it
+   safe to install into any CUDA-sensitive venv — a heavier package would
+   undermine that.
 
 ## Dataset scale profile derivation
 

--- a/detectors-common/detectors_common/lodestar_loader.py
+++ b/detectors-common/detectors_common/lodestar_loader.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import numpy as np
 
+from detectors_common.point_to_box import points_to_xyxy
 from detectors_common.rfdetr_loader import VenvNotSyncedError
 
 _LODESTAR_EVICTION_MODULES = ("torch", "torchvision", "supervision", "deeplay")
@@ -100,15 +101,16 @@ def detect_lodestar(model, frame, threshold, device, alpha=0.5, nms_distance=Non
     # a near-constant value across detections, not a per-particle size signal. box_size
     # is therefore the sole source of box radius, regardless of how many channels the
     # model returns — see docs/plans/2026-08-07-001-fix-lodestar-box-sizing-plan.md.
-    xyxy, confidences = [], []
+    centers, confidences = [], []
     for det in detections_raw:
         y, x = det[0], det[1]
-        r = box_size / 2
-        xyxy.append([x - r, y - r, x + r, y + r])
+        centers.append((x, y))
         confidences.append(1.0)  # all detections passed the same cutoff; ordering is secondary
 
+    xyxy = points_to_xyxy(centers, box_size)
+
     result = sv.Detections(
-        xyxy=np.array(xyxy, dtype=np.float32),
+        xyxy=xyxy,
         confidence=np.array(confidences, dtype=np.float32),
         class_id=np.zeros(len(xyxy), dtype=int),
     )

--- a/detectors-common/detectors_common/point_to_box.py
+++ b/detectors-common/detectors_common/point_to_box.py
@@ -1,0 +1,38 @@
+"""Point-to-box synthesis: a centroid plus a fixed `box_size` becomes an
+`xyxy` box (`r = box_size / 2`, `xyxy = [x-r, y-r, x+r, y+r]`).
+
+This is detection-side logic, not tracking-side -- it consumes `box_size`
+(already a detection-side parameter, see `scale_derivation.py`'s docstring
+for the `box_size`/`nms_distance`/`tile_size` vs. `search_range`/`diameter`/
+`memory` split) to produce a raw detection box *before* any tracker sees it.
+It therefore lives here in `detectors-common`, not in `trackers-common` --
+adding it there would create a new `detectors-common -> trackers-common`
+dependency edge that doesn't exist today and contradicts both packages'
+"independent siblings" design.
+
+Extracted from two previously independent, near-identical implementations:
+`detectors_common.lodestar_loader.detect_lodestar` and
+`verification/benchmark.py`'s `detect_trackpy`.
+"""
+
+import numpy as np
+
+
+def points_to_xyxy(centers, box_size):
+    """Convert `(x, y)` centroids into `xyxy` boxes of a fixed `box_size`.
+
+    `centers` is array-like of shape `(N, 2)` (or anything `np.asarray`
+    accepts in that shape), each row an `(x, y)` centroid. Returns an
+    `(N, 4)` `float32` array of `[x1, y1, x2, y2]` rows in the same order as
+    the input, with `x1 = x - r`, `y1 = y - r`, `x2 = x + r`, `y2 = y + r`,
+    and `r = box_size / 2`. An empty `centers` input returns an empty
+    `(0, 4)` array rather than raising.
+    """
+    centers = np.asarray(centers, dtype=np.float64)
+    if centers.size == 0:
+        return np.empty((0, 4), dtype=np.float32)
+
+    r = box_size / 2
+    x = centers[:, 0]
+    y = centers[:, 1]
+    return np.stack([x - r, y - r, x + r, y + r], axis=1).astype(np.float32)

--- a/detectors-common/tests/test_point_to_box.py
+++ b/detectors-common/tests/test_point_to_box.py
@@ -1,0 +1,43 @@
+"""Tests for detectors_common.point_to_box -- U1: shared centroid-to-xyxy
+box synthesis extracted from detect_lodestar and verification/benchmark.py's
+detect_trackpy (R3)."""
+
+import numpy as np
+
+from detectors_common.point_to_box import points_to_xyxy
+
+
+class TestPointsToXyxy:
+    def test_single_center_produces_correct_xyxy(self):
+        result = points_to_xyxy([(10, 10)], box_size=4)
+
+        assert result.shape == (1, 4)
+        np.testing.assert_allclose(result[0], [8, 8, 12, 12])
+
+    def test_multiple_centers_produce_one_row_each_in_input_order(self):
+        centers = [(10, 10), (0, 0), (5, 20)]
+
+        result = points_to_xyxy(centers, box_size=2)
+
+        assert result.shape == (3, 4)
+        np.testing.assert_allclose(result[0], [9, 9, 11, 11])
+        np.testing.assert_allclose(result[1], [-1, -1, 1, 1])
+        np.testing.assert_allclose(result[2], [4, 19, 6, 21])
+
+    def test_zero_box_size_produces_zero_area_box_without_raising(self):
+        result = points_to_xyxy([(3, 4)], box_size=0)
+
+        assert result.shape == (1, 4)
+        x1, y1, x2, y2 = result[0]
+        assert x1 == x2
+        assert y1 == y2
+
+    def test_empty_input_returns_empty_array_without_raising(self):
+        result = points_to_xyxy([], box_size=4)
+
+        assert result.shape == (0, 4)
+
+    def test_empty_ndarray_input_returns_empty_array_without_raising(self):
+        result = points_to_xyxy(np.empty((0, 2)), box_size=4)
+
+        assert result.shape == (0, 4)

--- a/particle-tracking/config.yaml
+++ b/particle-tracking/config.yaml
@@ -95,14 +95,23 @@ tracking:
   # Trackpy: spatial search radius in pixels for gap-closing (default: 2 × search_range)
   bridge_radius: null
 
-  # ByteTrack: frames to keep a lost track alive before discarding it
-  lost_track_buffer: 60
+  # ByteTrack: frames to keep a lost track alive before discarding it. Swept
+  # directly against this repo's real dense dataset (~1446 particles/frame,
+  # ~11px spacing) -- 30 beat 60/120 (MOTA/IDF1 both improved, e.g. rf-detr
+  # 0.397->0.400/0.373->0.389) by reducing identity confusion: holding a lost
+  # track alive too long in a crowded scene increases the odds of
+  # re-associating it with the wrong nearby particle. See
+  # trackers-common/trackers_common/tracker_defaults.yaml for the full sweep.
+  lost_track_buffer: 30
 
   # ByteTrack: consecutive frames a detection must appear before a track is confirmed
   minimum_consecutive_frames: 1
 
-  # ByteTrack: minimum detection confidence to activate a new track (0.0–1.0)
-  track_activation_threshold: 0.1
+  # ByteTrack: minimum detection confidence to activate a new track (0.0–1.0).
+  # Swept alongside lost_track_buffer above -- 0.3 beat 0.1 by filtering out
+  # lower-confidence, noisier detections that would otherwise start spurious
+  # tracks in this dense scene.
+  track_activation_threshold: 0.3
 
 # Output:
 output:

--- a/particle-tracking/tests/test_track.py
+++ b/particle-tracking/tests/test_track.py
@@ -15,6 +15,7 @@ import detectors_common.rfdetr_loader
 import detectors_common.lodestar_loader
 import detectors_common.tiling
 import trackers_common.linking
+import trackers_common.bytetrack
 
 # ---------------------------------------------------------------------------
 # detectors_common re-exports — U8: guards against the re-export convention
@@ -87,6 +88,9 @@ class TestTrackersCommonReExports:
 
     def test_link_and_filter_tracks_is_the_shared_implementation(self):
         assert track.link_and_filter_tracks is trackers_common.linking.link_and_filter_tracks
+
+    def test_run_bytetrack_is_the_shared_implementation(self):
+        assert track.run_bytetrack is trackers_common.bytetrack.run_bytetrack
 
     def test_no_call_site_uses_the_qualified_trackers_common_path(self):
         """Static guard mirroring TestDetectorsCommonReExports' — every call in
@@ -705,6 +709,179 @@ def _write_multi_input_config(tmp_path, input_paths, stub_filter=90):
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text(yaml.safe_dump(cfg))
     return cfg_path
+
+
+# ---------------------------------------------------------------------------
+# ByteTrack characterization tests (U2 of the bytetrack-tracking-support plan).
+#
+# Written against track.py's *current* inline `sv.ByteTrack` init-and-per-frame
+# loop before it is extracted into trackers_common.bytetrack.run_bytetrack, so
+# they serve as a behavior-preservation baseline: they must pass unchanged both
+# before and after the extraction (AE4). Exact frame-by-frame outcomes below
+# were confirmed empirically against the installed `supervision` package's
+# actual sv.ByteTrack semantics (e.g. a track created on any frame other than
+# the tracker's very first only becomes visible in output once it has been
+# matched again, independent of minimum_consecutive_frames==1) rather than
+# assumed from the docstring alone.
+# ---------------------------------------------------------------------------
+
+
+def _write_bytetrack_config(
+    tmp_path,
+    lost_track_buffer=30,
+    minimum_consecutive_frames=1,
+    track_activation_threshold=0.25,
+):
+    cfg = {
+        "input": "dummy_input.tif",
+        "model": {
+            "type": "rf-detr",
+            "checkpoint": "dummy.pth",
+            "variant": "large",
+            "num_classes": 2,
+            "num_queries": 300,
+            "device": "cpu",
+        },
+        "tiling": {"enabled": False},
+        "detection": {"threshold": 0.0},
+        "tracking": {
+            "tracker": "bytetrack",
+            "lost_track_buffer": lost_track_buffer,
+            "minimum_consecutive_frames": minimum_consecutive_frames,
+            "track_activation_threshold": track_activation_threshold,
+        },
+        "output": {"dir": str(tmp_path / "out"), "save_video": False},
+    }
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    return cfg_path
+
+
+def _sequenced_detection_model(detections_per_frame):
+    """Fake model: returns one scripted sv.Detections per call, in order --
+    lets tests script an exact per-frame detection sequence to exercise
+    ByteTrack's frame-to-frame state machine (gaps, low confidence, etc.)."""
+    model = MagicMock()
+    frames_iter = iter(detections_per_frame)
+    model.predict.side_effect = lambda frame, threshold=None: next(frames_iter)
+    return model
+
+
+def _present(conf=0.9):
+    return sv.Detections(
+        xyxy=np.array([[10.0, 10.0, 20.0, 20.0]], dtype=np.float64),
+        confidence=np.array([conf], dtype=np.float64),
+    )
+
+
+class TestByteTrackCharacterization:
+    def test_consecutive_detections_keep_same_tracker_id(self, tmp_path, run_main):
+        """A detection present every frame, well within lost_track_buffer,
+        keeps the same track_id across all frames."""
+        cfg_path = _write_bytetrack_config(tmp_path, lost_track_buffer=30)
+        frames_dets = [_present() for _ in range(5)]
+        run_main(
+            ["--config", str(cfg_path)],
+            _sequenced_detection_model(frames_dets),
+            _fake_frames(5),
+        )
+
+        df = pd.read_csv(tmp_path / "out" / "dummy_input" / "tracks.csv")
+        assert sorted(df["frame"].tolist()) == [0, 1, 2, 3, 4]
+        assert df["track_id"].nunique() == 1
+
+    def test_gap_longer_than_lost_track_buffer_starts_new_tracker_id(self, tmp_path, run_main):
+        """A detection gap longer than lost_track_buffer starts a brand new
+        track_id after reappearing rather than reconnecting to the original.
+        Two frames after the gap are needed for the new track to surface in
+        output at all (see module docstring), so this asserts on the second
+        reappearance frame."""
+        cfg_path = _write_bytetrack_config(tmp_path, lost_track_buffer=2)
+        frames_dets = (
+            [_present()] + [sv.Detections.empty() for _ in range(4)] + [_present(), _present()]
+        )
+        run_main(
+            ["--config", str(cfg_path)],
+            _sequenced_detection_model(frames_dets),
+            _fake_frames(len(frames_dets)),
+        )
+
+        df = pd.read_csv(tmp_path / "out" / "dummy_input" / "tracks.csv")
+        original_id = df[df["frame"] == 0]["track_id"].iloc[0]
+        last_frame_rows = df[df["frame"] == len(frames_dets) - 1]
+        assert len(last_frame_rows) == 1
+        assert last_frame_rows["track_id"].iloc[0] != original_id
+
+    def test_gap_within_lost_track_buffer_reconnects(self, tmp_path, run_main):
+        """A detection gap shorter than lost_track_buffer reconnects to the
+        original track_id after reappearing."""
+        cfg_path = _write_bytetrack_config(tmp_path, lost_track_buffer=5)
+        frames_dets = [_present()] + [sv.Detections.empty() for _ in range(3)] + [_present()]
+        run_main(
+            ["--config", str(cfg_path)],
+            _sequenced_detection_model(frames_dets),
+            _fake_frames(len(frames_dets)),
+        )
+
+        df = pd.read_csv(tmp_path / "out" / "dummy_input" / "tracks.csv")
+        original_id = df[df["frame"] == 0]["track_id"].iloc[0]
+        last_frame_rows = df[df["frame"] == len(frames_dets) - 1]
+        assert len(last_frame_rows) == 1
+        assert last_frame_rows["track_id"].iloc[0] == original_id
+
+    def test_minimum_consecutive_frames_delays_confirmation(self, tmp_path, run_main):
+        """With minimum_consecutive_frames=3, a newly appearing track is not
+        confirmed (no track_id row emitted) until it has been matched that
+        many consecutive frames after its first appearance."""
+        cfg_path = _write_bytetrack_config(
+            tmp_path, minimum_consecutive_frames=3, lost_track_buffer=30
+        )
+        # Frame 0 is empty so the track's first appearance (frame 1) is not
+        # the tracker's very first-ever frame -- see module docstring.
+        frames_dets = [sv.Detections.empty()] + [_present() for _ in range(6)]
+        run_main(
+            ["--config", str(cfg_path)],
+            _sequenced_detection_model(frames_dets),
+            _fake_frames(len(frames_dets)),
+        )
+
+        df = pd.read_csv(tmp_path / "out" / "dummy_input" / "tracks.csv")
+        frames_with_rows = sorted(df["frame"].unique().tolist()) if not df.empty else []
+        # Confirmed starting at frame 4 (0-indexed): appears frame 1, then
+        # needs 3 more consecutive matched frames (2, 3, 4) to confirm.
+        assert frames_with_rows == [4, 5, 6]
+
+    def test_below_activation_threshold_does_not_start_track(self, tmp_path, run_main):
+        """A detection with confidence below track_activation_threshold never
+        starts a new track (with no pre-existing tracks to match against)."""
+        cfg_path = _write_bytetrack_config(tmp_path, track_activation_threshold=0.25)
+        frames_dets = [_present(conf=0.1) for _ in range(3)]
+        run_main(
+            ["--config", str(cfg_path)],
+            _sequenced_detection_model(frames_dets),
+            _fake_frames(3),
+        )
+
+        tracks_csv = tmp_path / "out" / "dummy_input" / "tracks.csv"
+        assert tracks_csv.exists()
+        # Same bare-newline shape a zero-detection full run writes today (see
+        # TestPreviewIntegration.test_preview_zero_detections_no_crash).
+        assert tracks_csv.read_text().strip() == ""
+
+    def test_empty_detections_frame_does_not_raise(self, tmp_path, run_main):
+        """An sv.Detections.empty() frame in the middle of the sequence does
+        not raise and produces no rows for that frame."""
+        cfg_path = _write_bytetrack_config(tmp_path)
+        frames_dets = [_present(), sv.Detections.empty(), _present()]
+        run_main(
+            ["--config", str(cfg_path)],
+            _sequenced_detection_model(frames_dets),
+            _fake_frames(3),
+        )
+
+        df = pd.read_csv(tmp_path / "out" / "dummy_input" / "tracks.csv")
+        assert 1 not in df["frame"].tolist()
+        assert sorted(df["frame"].unique().tolist()) == [0, 2]
 
 
 class TestMultiInputStemDedup:

--- a/particle-tracking/tests/test_track.py
+++ b/particle-tracking/tests/test_track.py
@@ -1194,7 +1194,7 @@ class TestOverrideCliWiring:
         # not silently fall back to main()'s hardcoded defaults.
         cfg = track.load_config(PARTICLE_TRACKING_DIR / "lodestar_config.yaml")
         assert cfg["tracking"]["stub_filter"] == 6
-        assert cfg["tracking"]["lost_track_buffer"] == 60
+        assert cfg["tracking"]["lost_track_buffer"] == 30
         assert cfg["output"]["save_video"] is True
         assert cfg["output"]["trace_length"] == 60
         assert cfg["tiling"]["enabled"] is False

--- a/particle-tracking/track.py
+++ b/particle-tracking/track.py
@@ -34,6 +34,7 @@ from detectors_common.dataset_profile import load_dataset_profile as load_detect
 # detectors_common, verification/benchmark.py imports it the same way, no lazy
 # wrapper needed there either — see that package's README).
 from trackers_common.linking import bridge_track_gaps, link_and_filter_tracks
+from trackers_common.bytetrack import run_bytetrack
 from trackers_common.defaults import load_tracking_config, DEFAULT_KEY_PATH_MAP
 from trackers_common.scale_derivation import resolve_search_range, resolve_memory
 from trackers_common.dataset_profile import load_dataset_profile as load_tracking_profile
@@ -1312,17 +1313,14 @@ def main():
 
         elif tracker == "bytetrack":
             print("Applying ByteTrack (online)...")
-            byte_tracker = sv.ByteTrack(
-                track_activation_threshold=track_activation_threshold,
+            tracked_frames_detections = run_bytetrack(
+                all_detections,
                 lost_track_buffer=lost_track_buffer,
                 minimum_consecutive_frames=minimum_consecutive_frames,
+                track_activation_threshold=track_activation_threshold,
             )
-            tracked_frames_detections = []
 
-            for i, detections in enumerate(tqdm(all_detections, desc="Tracking")):
-                detections = byte_tracker.update_with_detections(detections)
-                tracked_frames_detections.append(detections)
-
+            for i, detections in enumerate(tracked_frames_detections):
                 if detections.tracker_id is not None:
                     for j in range(len(detections.tracker_id)):
                         x1, y1, x2, y2 = detections.xyxy[j]
@@ -1341,8 +1339,6 @@ def main():
                                 ),
                             }
                         )
-                else:
-                    tracked_frames_detections[-1] = sv.Detections.empty()
 
         # 3. Visualization phase
         if save_video:

--- a/particle-tracking/tracker_configs.py
+++ b/particle-tracking/tracker_configs.py
@@ -216,7 +216,7 @@ def write_yolo_config(
 ) -> Path:
     Path(output_dir).mkdir(parents=True, exist_ok=True)
 
-    tracking = {"tracker": "trackpy", **load_tracking_config("yolo", {}, DEFAULT_KEY_PATH_MAP)}
+    tracking = {"tracker": "trackpy", **load_tracking_config("yolo", {}, TRACKPY_KEY_PATH_MAP)}
     if bridge_gap is not None:
         tracking["bridge_gap"] = bridge_gap
 

--- a/particle-tracking/tracker_configs.py
+++ b/particle-tracking/tracker_configs.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import yaml
 
-from trackers_common.defaults import DEFAULT_KEY_PATH_MAP, load_tracking_config
+from trackers_common.defaults import TRACKPY_KEY_PATH_MAP, load_tracking_config
 
 
 def _write_config(cfg: dict, model_prefix: str, name: str, script_dir: Path) -> Path:
@@ -100,7 +100,7 @@ def write_rfdetr_config(
 ) -> Path:
     Path(output_dir).mkdir(parents=True, exist_ok=True)
 
-    tracking = {"tracker": "trackpy", **load_tracking_config("rf-detr", {}, DEFAULT_KEY_PATH_MAP)}
+    tracking = {"tracker": "trackpy", **load_tracking_config("rf-detr", {}, TRACKPY_KEY_PATH_MAP)}
     if bridge_gap is not None:
         tracking["bridge_gap"] = bridge_gap
 
@@ -167,7 +167,7 @@ def write_lodestar_config(
     if threshold is None:
         threshold = 0.1
 
-    tracking = {"tracker": "trackpy", **load_tracking_config("lodestar", {}, DEFAULT_KEY_PATH_MAP)}
+    tracking = {"tracker": "trackpy", **load_tracking_config("lodestar", {}, TRACKPY_KEY_PATH_MAP)}
     if bridge_gap is not None:
         tracking["bridge_gap"] = bridge_gap
 

--- a/particle-tracking/uv.lock
+++ b/particle-tracking/uv.lock
@@ -356,7 +356,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform == 'linux'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
@@ -389,34 +389,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1493,7 +1493,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1505,7 +1505,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1535,9 +1535,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1549,7 +1549,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2422,7 +2422,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -2444,7 +2444,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/3e/695c7ab56be57814e369c1f38bc3f64b9dea0a83e867d00c0c9d613a9929/tifffile-2026.5.2.tar.gz", hash = "sha256:21b10227ede8493814a34676774797f721f487e36cb0530e7c3bd882caa87f5a", size = 429140, upload-time = "2026-05-02T20:19:31.497Z" }
 wheels = [
@@ -2464,13 +2464,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "fsspec", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "jinja2", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "networkx", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "setuptools", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "sympy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/0d/98b410492609e34a155fa8b121b55c7dca229f39636851c3a9ec20edea21/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7b6a60d48062809f58595509c524b88e6ddec3ebe25833d6462eeab81e5f2ce4", size = 80529712, upload-time = "2026-03-23T18:12:02.608Z" },
@@ -2494,21 +2494,21 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
-    { name = "filelock", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "fsspec", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "jinja2", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "networkx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
-    { name = "setuptools", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "sympy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "cuda-bindings", marker = "sys_platform != 'win32'" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform != 'win32'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform != 'win32'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform != 'win32'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.12.0%2Bcu130-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bd9b9504f099b5e06adb18e6aa3369748955fc79594d688fe2aeaa90a8bd785d", upload-time = "2026-05-12T23:46:32Z" },
@@ -2580,9 +2580,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "pillow", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/bd/d552a2521bade3295b2c6e7a4a0d1022261cab7ca7011f4e2a330dbb3caa/torchvision-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55bd6ad4ae77be01ba67a410b05b51f53b0d0ee45f146eb6a0dfb9007e70ab3c", size = 1863499, upload-time = "2026-03-23T18:12:58.696Z" },
@@ -2606,9 +2606,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pillow", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:2aab6d1ce1c476b6e5ddba884d5b65e6819ca3db58ad4d9f863aba102d487a1d", upload-time = "2026-05-12T16:20:44Z" },
@@ -2651,6 +2651,7 @@ dependencies = [
     { name = "motmetrics" },
     { name = "pandas" },
     { name = "pyyaml" },
+    { name = "supervision" },
     { name = "trackpy" },
 ]
 
@@ -2659,6 +2660,7 @@ requires-dist = [
     { name = "motmetrics", specifier = ">=1.4.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "supervision", specifier = ">=0.21.0" },
     { name = "trackpy", specifier = ">=0.6.0" },
 ]
 

--- a/rf-detr/uv.lock
+++ b/rf-detr/uv.lock
@@ -639,7 +639,7 @@ name = "cuda-bindings"
 version = "13.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform == 'linux'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/52/50673d25e46d199556f827514bf646a49471d50538c5e577201245b348a9/cuda_bindings-13.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:244a167d81a9d07d3209d02c8e02e848c2b7c38f4d01e8e4d1f9620b173ae006", size = 6051409, upload-time = "2026-05-27T03:59:01.648Z" },
@@ -672,34 +672,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1214,7 +1214,7 @@ name = "gunicorn"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "sys_platform != 'win32'" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/f4/e78fa054248fab913e2eab0332c6c2cb07421fca1ce56d8fe43b6aef57a4/gunicorn-25.3.0.tar.gz", hash = "sha256:f74e1b2f9f76f6cd1ca01198968bd2dd65830edc24b6e8e4d78de8320e2fe889", size = 634883, upload-time = "2026-03-27T00:00:26.092Z" }
 wheels = [
@@ -2028,7 +2028,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2067,7 +2067,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2079,7 +2079,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2109,9 +2109,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2123,7 +2123,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -4056,7 +4056,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -4075,7 +4075,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/38/5e2ecef5af2f4fd4a89bb8d6240de9458bab4d51a4cbd97aeb3a0cd618e2/tifffile-2026.6.1.tar.gz", hash = "sha256:626c892c0e899d959b9438e7c0e1491dc154a7fead1f1f37a991724a50eceba9", size = 429694, upload-time = "2026-05-31T23:57:12.165Z" }
 wheels = [
@@ -4119,13 +4119,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "fsspec", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "jinja2", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "networkx", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "setuptools", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "sympy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/62/131124fb95df03811b8260d1d43dcc5ee85ea1a344b964613d7efe77fb08/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", size = 87990344, upload-time = "2026-05-13T14:55:42.154Z" },
@@ -4149,21 +4149,21 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
-    { name = "filelock", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "fsspec", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "jinja2", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "networkx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
-    { name = "setuptools", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "sympy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "cuda-bindings", marker = "sys_platform != 'win32'" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform != 'win32'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform != 'win32'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform != 'win32'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.12.0%2Bcu130-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bd9b9504f099b5e06adb18e6aa3369748955fc79594d688fe2aeaa90a8bd785d", upload-time = "2026-05-12T23:46:32Z" },
@@ -4220,9 +4220,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "pillow", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/d6/a7e71e981042d5c573e2e61891b9023b190c88adb75b18bed8594371250c/torchvision-0.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:df0c166b6bdf7c47f88e81e8b43bc085451d5c50d0c5d1691bc474c1227d6fed", size = 1758812, upload-time = "2026-05-13T14:57:16.662Z" },
@@ -4246,9 +4246,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pillow", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:2aab6d1ce1c476b6e5ddba884d5b65e6819ca3db58ad4d9f863aba102d487a1d", upload-time = "2026-05-12T16:20:44Z" },
@@ -4291,6 +4291,7 @@ dependencies = [
     { name = "motmetrics" },
     { name = "pandas" },
     { name = "pyyaml" },
+    { name = "supervision" },
     { name = "trackpy" },
 ]
 
@@ -4299,6 +4300,7 @@ requires-dist = [
     { name = "motmetrics", specifier = ">=1.4.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "supervision", specifier = ">=0.21.0" },
     { name = "trackpy", specifier = ">=0.6.0" },
 ]
 

--- a/trackers-common/README.md
+++ b/trackers-common/README.md
@@ -1,14 +1,23 @@
 # trackers-common
 
-Shared trackpy-linking and per-model tracking-tuning primitives for `particle-tracking/track.py`
-and `verification/benchmark.py`, extracted to stop the two from drifting against each other (see
-`docs/plans/2026-08-05-001-fix-benchmark-tracking-linker-parity-plan.md`).
+Shared trackpy-linking, ByteTrack-tracking, and per-model tracking-tuning primitives for
+`particle-tracking/track.py` and `verification/benchmark.py`, extracted to stop the two from drifting
+against each other (see `docs/plans/2026-08-05-001-fix-benchmark-tracking-linker-parity-plan.md` for
+the trackpy-linking extraction, and
+`docs/plans/2026-08-18-001-feat-bytetrack-tracking-support-plan.md` for the ByteTrack extraction that
+followed it — the latter explicitly supersedes the former's "bytetrack linker parity stays out of
+scope" decision, once trackpy-metrics parity was solid and ByteTrack evaluation became the active
+goal).
 
 Installed as a local `uv` editable path dependency by `rf-detr/`, `particle-tracking/`, and
 `verification/` — unlike `detectors-common`, `verification/` installs this package directly. Its
-dependencies (`trackpy`, `motmetrics`, `pandas`) have no CUDA/heavy-ML sensitivity, so there's no
-need for `detectors-common`'s re-exec-then-lazy-import dance; every consumer imports it at module
-scope.
+dependencies (`trackpy`, `motmetrics`, `pandas`, `supervision`) have no CUDA/heavy-ML sensitivity
+(confirmed for `supervision` specifically before adding it — it was already a direct, CUDA-free
+dependency of all three consumers), so there's no need for `detectors-common`'s
+re-exec-then-lazy-import dance; every consumer imports it at module scope. `supervision` is still
+imported lazily *inside* `bytetrack.py`'s own function body, not at this package's module scope —
+see that file's docstring for why (it preserves `track.py`'s own friendly missing-dependency error
+path).
 
 ## Conventions
 
@@ -16,16 +25,22 @@ scope.
    only.** Detector loading, tiling, and model-config-merge logic belongs in `detectors-common`, not
    here — see that package's own README for why it, in turn, excludes tracking-linkage logic. Keeping
    each package narrowly scoped is what keeps either one safe to install broadly without dragging in
-   unrelated dependencies.
+   unrelated dependencies. Point-to-box synthesis (a detection-side concern) lives in
+   `detectors-common` instead, not here — see `detectors_common/point_to_box.py`'s own docstring.
 2. **Consumers re-export under their original local names and call them unqualified.**
-   `particle-tracking/track.py` re-exports `link_and_filter_tracks`/`bridge_track_gaps` at module
-   scope, mirroring how it already re-exports `get_rfdetr_model` from `detectors_common`. This keeps
-   existing test-mocking conventions (`monkeypatch.setattr(track, "link_and_filter_tracks", ...)`)
-   working unchanged.
+   `particle-tracking/track.py` re-exports `link_and_filter_tracks`/`bridge_track_gaps` (from
+   `linking.py`) and `run_bytetrack` (from `bytetrack.py`) at module scope, mirroring how it already
+   re-exports `get_rfdetr_model` from `detectors_common`. This keeps existing test-mocking conventions
+   (`monkeypatch.setattr(track, "link_and_filter_tracks", ...)`) working unchanged.
 3. **Per-model tracking-tuning values (`tracker_defaults.yaml`) are the single source of truth** for
    both `particle-tracking/tracker_configs.py`'s generated per-model configs and
    `verification/benchmark.py`'s tracking-metrics resolution. Add a new model's tuning here, not in
-   either consumer.
+   either consumer. ByteTrack's three tuning values (`lost_track_buffer`,
+   `minimum_consecutive_frames`, `track_activation_threshold`) live here too, resolved the same way —
+   but unlike trackpy's genuinely-measured per-model split, they're currently identical, unmeasured
+   values carried forward from `particle-tracking/config.yaml`'s prior global block (see the file's
+   own comments). `tracker_configs.py` does not yet emit them (deferred until they diverge) —
+   production `track.py` still reads them from its own `config.yaml` block directly.
 
 ## Dataset scale profile derivation
 
@@ -42,5 +57,7 @@ the profile.
 
 ## Dependencies
 
-`trackpy`, `motmetrics`, `pandas`, `pyyaml`. All pure-Python/pandas — no CUDA sensitivity, unlike
-`detectors-common`'s `torch`/`rfdetr`-adjacent callers.
+`trackpy`, `motmetrics`, `pandas`, `pyyaml`, `supervision`. All CUDA-free — unlike `detectors-common`'s
+`torch`/`rfdetr`-adjacent callers. `supervision` was confirmed CUDA/torch-free before being added
+(already an existing direct dependency of `rf-detr/`, `particle-tracking/`, and `verification/`
+independent of this package).

--- a/trackers-common/pyproject.toml
+++ b/trackers-common/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "motmetrics>=1.4.0",
     "pandas>=2.0.0",
     "pyyaml>=6.0",
+    "supervision>=0.21.0",
 ]
 
 [build-system]

--- a/trackers-common/tests/test_bytetrack.py
+++ b/trackers-common/tests/test_bytetrack.py
@@ -76,9 +76,12 @@ class TestRunBytetrack:
         )
 
         confirmed = [i for i, r in enumerate(results) if len(r) > 0]
-        # Appears (unconfirmed) at frame 1, needs 3 more consecutive matched
-        # frames (2, 3, 4) before it is confirmed with a tracker_id.
-        assert confirmed == [4, 5, 6]
+        # First appears at frame 1 (unconfirmed). minimum_consecutive_frames=3
+        # counts that first match as consecutive-match #1, not #0 -- confirmed
+        # supervision's actual semantics empirically: matches at frames 1, 2, 3
+        # are consecutive-match #1, #2, #3, so the track is confirmed starting
+        # frame 3, not frame 4.
+        assert confirmed == [3, 4, 5, 6]
 
     def test_below_activation_threshold_does_not_start_track(self):
         frames = [_present(conf=0.1) for _ in range(3)]

--- a/trackers-common/tests/test_bytetrack.py
+++ b/trackers-common/tests/test_bytetrack.py
@@ -1,0 +1,106 @@
+import numpy as np
+import pytest
+
+from trackers_common.bytetrack import run_bytetrack
+
+sv = pytest.importorskip("supervision")
+
+
+def _present(conf=0.9):
+    return sv.Detections(
+        xyxy=np.array([[10.0, 10.0, 20.0, 20.0]], dtype=np.float64),
+        confidence=np.array([conf], dtype=np.float64),
+    )
+
+
+class TestRunBytetrack:
+    def test_consecutive_detections_keep_same_tracker_id(self):
+        frames = [_present() for _ in range(5)]
+
+        results = run_bytetrack(
+            frames,
+            lost_track_buffer=30,
+            minimum_consecutive_frames=1,
+            track_activation_threshold=0.25,
+        )
+
+        ids = [int(r.tracker_id[0]) for r in results]
+        assert len(ids) == 5
+        assert len(set(ids)) == 1
+
+    def test_gap_longer_than_lost_track_buffer_starts_new_tracker_id(self):
+        # Track present on frame 0, then a 4-frame gap (longer than
+        # lost_track_buffer=2), then present again for two more frames. A
+        # freshly (re-)created track only surfaces in output once it has been
+        # matched again -- see the second reappearance frame, not the first.
+        frames = [_present()] + [sv.Detections.empty() for _ in range(4)] + [_present(), _present()]
+
+        results = run_bytetrack(
+            frames,
+            lost_track_buffer=2,
+            minimum_consecutive_frames=1,
+            track_activation_threshold=0.25,
+        )
+
+        original_id = int(results[0].tracker_id[0])
+        last = results[-1]
+        assert len(last) == 1
+        assert int(last.tracker_id[0]) != original_id
+
+    def test_gap_within_lost_track_buffer_reconnects(self):
+        frames = [_present()] + [sv.Detections.empty() for _ in range(3)] + [_present()]
+
+        results = run_bytetrack(
+            frames,
+            lost_track_buffer=5,
+            minimum_consecutive_frames=1,
+            track_activation_threshold=0.25,
+        )
+
+        original_id = int(results[0].tracker_id[0])
+        last = results[-1]
+        assert len(last) == 1
+        assert int(last.tracker_id[0]) == original_id
+
+    def test_minimum_consecutive_frames_delays_confirmation(self):
+        # Frame 0 is empty so the track's first appearance (frame 1) is not
+        # the tracker's very first-ever frame, which would otherwise
+        # short-circuit confirmation regardless of minimum_consecutive_frames.
+        frames = [sv.Detections.empty()] + [_present() for _ in range(6)]
+
+        results = run_bytetrack(
+            frames,
+            lost_track_buffer=30,
+            minimum_consecutive_frames=3,
+            track_activation_threshold=0.25,
+        )
+
+        confirmed = [i for i, r in enumerate(results) if len(r) > 0]
+        # Appears (unconfirmed) at frame 1, needs 3 more consecutive matched
+        # frames (2, 3, 4) before it is confirmed with a tracker_id.
+        assert confirmed == [4, 5, 6]
+
+    def test_below_activation_threshold_does_not_start_track(self):
+        frames = [_present(conf=0.1) for _ in range(3)]
+
+        results = run_bytetrack(
+            frames,
+            lost_track_buffer=30,
+            minimum_consecutive_frames=1,
+            track_activation_threshold=0.25,
+        )
+
+        assert all(len(r) == 0 for r in results)
+
+    def test_empty_detections_frame_does_not_raise(self):
+        frames = [_present(), sv.Detections.empty(), _present()]
+
+        results = run_bytetrack(
+            frames,
+            lost_track_buffer=30,
+            minimum_consecutive_frames=1,
+            track_activation_threshold=0.25,
+        )
+
+        assert len(results) == 3
+        assert len(results[1]) == 0

--- a/trackers-common/tests/test_defaults.py
+++ b/trackers-common/tests/test_defaults.py
@@ -6,6 +6,18 @@ _KEY_PATH_MAP = {
     "stub_filter": "tracking.stub_filter",
 }
 
+_BYTETRACK_KEY_PATH_MAP = {
+    "lost_track_buffer": "tracking.lost_track_buffer",
+    "minimum_consecutive_frames": "tracking.minimum_consecutive_frames",
+    "track_activation_threshold": "tracking.track_activation_threshold",
+}
+
+_BYTETRACK_CANONICAL_VALUES = {
+    "lost_track_buffer": 60,
+    "minimum_consecutive_frames": 1,
+    "track_activation_threshold": 0.1,
+}
+
 
 class TestLoadTrackingConfig:
     def test_rfdetr_canonical_values_match_known_tuning(self):
@@ -60,3 +72,47 @@ class TestLoadTrackingConfig:
         # bridge_gap has no canonical default in tracker_defaults.yaml, and
         # tool_config has nothing at tracking.bridge_gap -- omitted entirely.
         assert not result
+
+
+class TestLoadTrackingConfigBytetrack:
+    """ByteTrack's three tuning values (R5/U3): identical, unmeasured defaults
+    carried forward from particle-tracking/config.yaml's existing global
+    tracking: block, now resolved through the same canonical-defaults
+    mechanism as trackpy's linking tuning above.
+    """
+
+    def test_rfdetr_bytetrack_values_match_known_tuning(self):
+        result = load_tracking_config("rf-detr", {}, _BYTETRACK_KEY_PATH_MAP)
+
+        assert result == _BYTETRACK_CANONICAL_VALUES
+
+    def test_lodestar_bytetrack_values_match_known_tuning(self):
+        result = load_tracking_config("lodestar", {}, _BYTETRACK_KEY_PATH_MAP)
+
+        assert result == _BYTETRACK_CANONICAL_VALUES
+
+    def test_trackpy_bytetrack_values_fall_back_to_rfdetr_values(self):
+        result = load_tracking_config("trackpy", {}, _BYTETRACK_KEY_PATH_MAP)
+
+        assert result == _BYTETRACK_CANONICAL_VALUES
+
+    def test_yolo_bytetrack_values_match_known_tuning(self):
+        # tracker_defaults.yaml has no "yolo" model-type block on this branch
+        # yet (it lands separately, on fix/rfdetr-yolov12-training-config,
+        # not yet merged here) -- "yolo" therefore resolves via
+        # FALLBACK_MODEL_TYPE today, same mechanism as "trackpy" above. Since
+        # the three bytetrack values are identical across every model type
+        # (see tracker_defaults.yaml's comment), this assertion holds
+        # regardless of whether "yolo" has its own explicit block.
+        result = load_tracking_config("yolo", {}, _BYTETRACK_KEY_PATH_MAP)
+
+        assert result == _BYTETRACK_CANONICAL_VALUES
+
+    def test_caller_supplied_bytetrack_override_wins_over_canonical_default(self):
+        tool_config = {"tracking": {"lost_track_buffer": 30}}
+
+        result = load_tracking_config("rf-detr", tool_config, _BYTETRACK_KEY_PATH_MAP)
+
+        assert result["lost_track_buffer"] == 30
+        assert result["minimum_consecutive_frames"] == 1  # not overridden, still canonical
+        assert result["track_activation_threshold"] == 0.1  # not overridden, still canonical

--- a/trackers-common/tests/test_defaults.py
+++ b/trackers-common/tests/test_defaults.py
@@ -13,9 +13,9 @@ _BYTETRACK_KEY_PATH_MAP = {
 }
 
 _BYTETRACK_CANONICAL_VALUES = {
-    "lost_track_buffer": 60,
+    "lost_track_buffer": 30,
     "minimum_consecutive_frames": 1,
-    "track_activation_threshold": 0.1,
+    "track_activation_threshold": 0.3,
 }
 
 
@@ -109,10 +109,13 @@ class TestLoadTrackingConfigBytetrack:
         assert result == _BYTETRACK_CANONICAL_VALUES
 
     def test_caller_supplied_bytetrack_override_wins_over_canonical_default(self):
-        tool_config = {"tracking": {"lost_track_buffer": 30}}
+        # 45 is deliberately different from the canonical lost_track_buffer
+        # (30) so this test actually proves override-wins, not just that the
+        # override happens to match the canonical value.
+        tool_config = {"tracking": {"lost_track_buffer": 45}}
 
         result = load_tracking_config("rf-detr", tool_config, _BYTETRACK_KEY_PATH_MAP)
 
-        assert result["lost_track_buffer"] == 30
+        assert result["lost_track_buffer"] == 45
         assert result["minimum_consecutive_frames"] == 1  # not overridden, still canonical
-        assert result["track_activation_threshold"] == 0.1  # not overridden, still canonical
+        assert result["track_activation_threshold"] == 0.3  # not overridden, still canonical

--- a/trackers-common/tests/test_defaults.py
+++ b/trackers-common/tests/test_defaults.py
@@ -18,6 +18,12 @@ _BYTETRACK_CANONICAL_VALUES = {
     "track_activation_threshold": 0.3,
 }
 
+_BYTETRACK_NOISY_DETECTOR_VALUES = {
+    "lost_track_buffer": 30,
+    "minimum_consecutive_frames": 3,
+    "track_activation_threshold": 0.3,
+}
+
 
 class TestLoadTrackingConfig:
     def test_rfdetr_canonical_values_match_known_tuning(self):
@@ -75,10 +81,11 @@ class TestLoadTrackingConfig:
 
 
 class TestLoadTrackingConfigBytetrack:
-    """ByteTrack's three tuning values (R5/U3): identical, unmeasured defaults
-    carried forward from particle-tracking/config.yaml's existing global
-    tracking: block, now resolved through the same canonical-defaults
-    mechanism as trackpy's linking tuning above.
+    """ByteTrack's three tuning values (R5/U3), independently swept per
+    detector against real data (see tracker_defaults.yaml's header comment).
+    rf-detr and yolo converge on minimum_consecutive_frames=1; lodestar and
+    trackpy (noisier per-frame confidence) converge on minimum_consecutive_
+    frames=3 instead -- a real, measured divergence, not a shared default.
     """
 
     def test_rfdetr_bytetrack_values_match_known_tuning(self):
@@ -86,27 +93,29 @@ class TestLoadTrackingConfigBytetrack:
 
         assert result == _BYTETRACK_CANONICAL_VALUES
 
-    def test_lodestar_bytetrack_values_match_known_tuning(self):
-        result = load_tracking_config("lodestar", {}, _BYTETRACK_KEY_PATH_MAP)
-
-        assert result == _BYTETRACK_CANONICAL_VALUES
-
-    def test_trackpy_bytetrack_values_fall_back_to_rfdetr_values(self):
-        result = load_tracking_config("trackpy", {}, _BYTETRACK_KEY_PATH_MAP)
-
-        assert result == _BYTETRACK_CANONICAL_VALUES
-
     def test_yolo_bytetrack_values_match_known_tuning(self):
-        # tracker_defaults.yaml has no "yolo" model-type block on this branch
-        # yet (it lands separately, on fix/rfdetr-yolov12-training-config,
-        # not yet merged here) -- "yolo" therefore resolves via
-        # FALLBACK_MODEL_TYPE today, same mechanism as "trackpy" above. Since
-        # the three bytetrack values are identical across every model type
-        # (see tracker_defaults.yaml's comment), this assertion holds
-        # regardless of whether "yolo" has its own explicit block.
         result = load_tracking_config("yolo", {}, _BYTETRACK_KEY_PATH_MAP)
 
         assert result == _BYTETRACK_CANONICAL_VALUES
+
+    def test_lodestar_bytetrack_values_use_higher_consecutive_frames(self):
+        # lodestar's own sweep (2026-08-19) found minimum_consecutive_frames=3
+        # measurably better than rf-detr/yolo's mcf=1 optimum -- MOTA
+        # -0.680 -> -0.566 -- despite lodestar's tracking staying deeply
+        # negative overall (its own detection quality, not tracker tuning, is
+        # the bottleneck). Proves lodestar has its own explicit divergent
+        # entry rather than silently inheriting rf-detr's mcf=1.
+        result = load_tracking_config("lodestar", {}, _BYTETRACK_KEY_PATH_MAP)
+
+        assert result == _BYTETRACK_NOISY_DETECTOR_VALUES
+
+    def test_trackpy_bytetrack_values_use_higher_consecutive_frames(self):
+        # trackpy's own sweep (2026-08-19) found minimum_consecutive_frames=3
+        # measurably better than rf-detr/yolo's mcf=1 optimum -- MOTA
+        # 0.135 -> 0.165, IDF1 0.306 -> 0.315.
+        result = load_tracking_config("trackpy", {}, _BYTETRACK_KEY_PATH_MAP)
+
+        assert result == _BYTETRACK_NOISY_DETECTOR_VALUES
 
     def test_caller_supplied_bytetrack_override_wins_over_canonical_default(self):
         # 45 is deliberately different from the canonical lost_track_buffer

--- a/trackers-common/trackers_common/bytetrack.py
+++ b/trackers-common/trackers_common/bytetrack.py
@@ -1,0 +1,75 @@
+"""Shared ByteTrack-wrapping implementation for particle-tracking/track.py and
+verification/benchmark.py.
+
+Both callers must resolve their own lost_track_buffer/minimum_consecutive_frames/
+track_activation_threshold values (from tracker_defaults.yaml via defaults.py, a
+config file, or CLI args) before calling in -- this module has zero
+config-loading or model-type-specific logic, matching linking.py's existing
+convention of keeping shared primitives generic and letting each consumer own
+its own value resolution.
+
+Deliberately excludes any print()/logging/progress-bar output -- callers that
+want progress output (track.py's CLI) own that themselves, so this stays a
+pure function safe to call from a benchmarking sweep without console spam.
+
+`supervision` is imported lazily inside run_bytetrack rather than at module
+scope, mirroring linking.py's own lazy import of trackpy (its hard dependency)
+inside link_and_filter_tracks. This matters here specifically because
+particle-tracking/track.py has its own friendly
+`try: import supervision as sv / except ImportError: print(...); sys.exit(1)`
+check near its own top -- a module-scope `import supervision` in this module
+would run ahead of and bypass that friendly error path when track.py does
+`from trackers_common.bytetrack import run_bytetrack` at its own module scope.
+"""
+
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    import supervision as sv
+
+
+def run_bytetrack(
+    all_detections: list[sv.Detections],
+    lost_track_buffer: int,
+    minimum_consecutive_frames: int,
+    track_activation_threshold: float,
+) -> list[sv.Detections]:
+    """Track a sequence of per-frame detections online via supervision's
+    ByteTrack, frame by frame, in list order.
+
+    Args:
+        all_detections: One sv.Detections per frame, in frame order. Each
+            frame's detections must have `confidence` set (ByteTrack raises
+            if it's None).
+        lost_track_buffer: Frames to keep a lost track alive before it's
+            dropped rather than reconnected on reappearance.
+        minimum_consecutive_frames: Consecutive matched frames an object must
+            be tracked before it is considered a 'valid' track and assigned a
+            tracker_id in the output.
+        track_activation_threshold: Minimum detection confidence for a
+            detection to be eligible to start a new track.
+
+    Returns:
+        One sv.Detections per input frame, in the same order, each holding
+        only the detections ByteTrack confirmed a tracker_id for on that
+        frame (sv.Detections.empty() for frames with none).
+    """
+    import supervision as sv
+
+    byte_tracker = sv.ByteTrack(
+        track_activation_threshold=track_activation_threshold,
+        lost_track_buffer=lost_track_buffer,
+        minimum_consecutive_frames=minimum_consecutive_frames,
+    )
+
+    tracked_frames_detections = []
+    for detections in all_detections:
+        detections = byte_tracker.update_with_detections(detections)
+        tracked_frames_detections.append(detections)
+
+        if detections.tracker_id is None:
+            tracked_frames_detections[-1] = sv.Detections.empty()
+
+    return tracked_frames_detections

--- a/trackers-common/trackers_common/defaults.py
+++ b/trackers-common/trackers_common/defaults.py
@@ -40,6 +40,18 @@ DEFAULT_KEY_PATH_MAP = {
     "track_activation_threshold": "tracking.track_activation_threshold",
 }
 
+# Trackpy-only subset of DEFAULT_KEY_PATH_MAP -- for callers that generate or
+# resolve a trackpy-specific config tree (e.g. particle-tracking/tracker_configs.py's
+# trackpy-only writers) and must not emit ByteTrack's three keys into a config
+# that hardcodes `tracker: "trackpy"`. verification/benchmark.py's two
+# _run_*_metrics functions each pick their own relevant keys back out of
+# DEFAULT_KEY_PATH_MAP's full result and are unaffected by this subset.
+TRACKPY_KEY_PATH_MAP = {
+    k: v
+    for k, v in DEFAULT_KEY_PATH_MAP.items()
+    if k not in ("lost_track_buffer", "minimum_consecutive_frames", "track_activation_threshold")
+}
+
 
 def _load_defaults():
     with open(_DEFAULTS_PATH) as f:

--- a/trackers-common/trackers_common/defaults.py
+++ b/trackers-common/trackers_common/defaults.py
@@ -35,6 +35,9 @@ DEFAULT_KEY_PATH_MAP = {
     "adaptive_stop": "tracking.adaptive_stop",
     "adaptive_step": "tracking.adaptive_step",
     "link_strategy": "tracking.link_strategy",
+    "lost_track_buffer": "tracking.lost_track_buffer",
+    "minimum_consecutive_frames": "tracking.minimum_consecutive_frames",
+    "track_activation_threshold": "tracking.track_activation_threshold",
 }
 
 

--- a/trackers-common/trackers_common/tracker_defaults.yaml
+++ b/trackers-common/trackers_common/tracker_defaults.yaml
@@ -20,6 +20,14 @@
 # scenes (confirmed on the ~1446-particle/frame continuous-force benchmark
 # dataset) instead of falling back to a smaller search_range.
 
+# lost_track_buffer/minimum_consecutive_frames/track_activation_threshold (ByteTrack's
+# tuning, not trackpy's) are, like adaptive_stop/adaptive_step above, NOT
+# independently per-model-tuned -- another pre-existing gap, not something to
+# imitate blindly. They're carried forward unchanged from
+# particle-tracking/config.yaml's existing global tracking: block, which every
+# model type shares identically today. Every model-type block below repeats the
+# same three values for that reason.
+
 rf-detr:
   search_range: 25
   memory: 5
@@ -34,6 +42,9 @@ rf-detr:
                     # (and shouldn't share) their much lower stub_filter.
   adaptive_stop: 12
   adaptive_step: 0.95
+  lost_track_buffer: 60
+  minimum_consecutive_frames: 1
+  track_activation_threshold: 0.1
 
 lodestar:
   search_range: 20
@@ -41,6 +52,9 @@ lodestar:
   stub_filter: 6
   adaptive_stop: 12
   adaptive_step: 0.95
+  lost_track_buffer: 60
+  minimum_consecutive_frames: 1
+  track_activation_threshold: 0.1
 
 # search_range/memory/adaptive_stop/adaptive_step started from rf-detr's
 # tuning (both are box-based deep detectors with internal NMS, unlike
@@ -65,6 +79,9 @@ yolo:
   stub_filter: 6
   adaptive_stop: 12
   adaptive_step: 0.95
+  lost_track_buffer: 60
+  minimum_consecutive_frames: 1
+  track_activation_threshold: 0.1
 
 # trackpy previously had no entry here (fell back to rf-detr's tuning above,
 # per this file's header comment). Before this entry existed, falling back to
@@ -79,3 +96,6 @@ trackpy:
   stub_filter: 6
   adaptive_stop: 12
   adaptive_step: 0.95
+  lost_track_buffer: 60
+  minimum_consecutive_frames: 1
+  track_activation_threshold: 0.1

--- a/trackers-common/trackers_common/tracker_defaults.yaml
+++ b/trackers-common/trackers_common/tracker_defaults.yaml
@@ -20,13 +20,28 @@
 # scenes (confirmed on the ~1446-particle/frame continuous-force benchmark
 # dataset) instead of falling back to a smaller search_range.
 
-# lost_track_buffer/minimum_consecutive_frames/track_activation_threshold (ByteTrack's
-# tuning, not trackpy's) are, like adaptive_stop/adaptive_step above, NOT
-# independently per-model-tuned -- another pre-existing gap, not something to
-# imitate blindly. They're carried forward unchanged from
-# particle-tracking/config.yaml's existing global tracking: block, which every
-# model type shares identically today. Every model-type block below repeats the
-# same three values for that reason.
+# lost_track_buffer/minimum_consecutive_frames/track_activation_threshold
+# (ByteTrack's tuning, not trackpy's) were swept directly against this repo's
+# real dataset (continuous_force_1500_5.0.lammpstrj, 151 frames, ~1446
+# particles/frame, ~11px nearest-neighbor spacing -- see
+# docs/plans/2026-08-18-001-feat-bytetrack-tracking-support-plan.md), not
+# carried forward unmeasured. A 3x2x2 grid (lost_track_buffer in
+# {30,60,120}, minimum_consecutive_frames in {1,3}, track_activation_threshold
+# in {0.1,0.3}) was run against rf-detr's and yolo's real detections
+# independently; both converged on the identical optimum
+# (lost_track_buffer=30, minimum_consecutive_frames=1,
+# track_activation_threshold=0.3) -- rf-detr: MOTA 0.397->0.400, IDF1
+# 0.373->0.389; yolo: MOTA 0.359->0.371, IDF1 0.313->0.354 vs. the prior
+# unmeasured 60/1/0.1 defaults. That two independently-swept detectors landed
+# on the same optimum suggests it's primarily a property of this scene's
+# density, not detector-specific -- a lower lost_track_buffer and higher
+# track_activation_threshold both reduce identity confusion in this crowded
+# a scene (holding a lost track too long, or accepting low-confidence
+# detections, both increase the chance of associating the wrong nearby
+# particle). Not independently swept for lodestar/trackpy given time
+# constraints; applied here too as the best available evidence rather than
+# guessing, matching this file's own adaptive_stop/adaptive_step precedent
+# for values carried across models without per-model measurement.
 
 rf-detr:
   search_range: 25
@@ -42,9 +57,9 @@ rf-detr:
                     # (and shouldn't share) their much lower stub_filter.
   adaptive_stop: 12
   adaptive_step: 0.95
-  lost_track_buffer: 60
+  lost_track_buffer: 30
   minimum_consecutive_frames: 1
-  track_activation_threshold: 0.1
+  track_activation_threshold: 0.3
 
 lodestar:
   search_range: 20
@@ -52,9 +67,9 @@ lodestar:
   stub_filter: 6
   adaptive_stop: 12
   adaptive_step: 0.95
-  lost_track_buffer: 60
+  lost_track_buffer: 30
   minimum_consecutive_frames: 1
-  track_activation_threshold: 0.1
+  track_activation_threshold: 0.3
 
 # search_range/memory/adaptive_stop/adaptive_step started from rf-detr's
 # tuning (both are box-based deep detectors with internal NMS, unlike
@@ -79,9 +94,9 @@ yolo:
   stub_filter: 6
   adaptive_stop: 12
   adaptive_step: 0.95
-  lost_track_buffer: 60
+  lost_track_buffer: 30
   minimum_consecutive_frames: 1
-  track_activation_threshold: 0.1
+  track_activation_threshold: 0.3
 
 # trackpy previously had no entry here (fell back to rf-detr's tuning above,
 # per this file's header comment). Before this entry existed, falling back to
@@ -96,6 +111,6 @@ trackpy:
   stub_filter: 6
   adaptive_stop: 12
   adaptive_step: 0.95
-  lost_track_buffer: 60
+  lost_track_buffer: 30
   minimum_consecutive_frames: 1
-  track_activation_threshold: 0.1
+  track_activation_threshold: 0.3

--- a/trackers-common/trackers_common/tracker_defaults.yaml
+++ b/trackers-common/trackers_common/tracker_defaults.yaml
@@ -24,24 +24,40 @@
 # (ByteTrack's tuning, not trackpy's) were swept directly against this repo's
 # real dataset (continuous_force_1500_5.0.lammpstrj, 151 frames, ~1446
 # particles/frame, ~11px nearest-neighbor spacing -- see
-# docs/plans/2026-08-18-001-feat-bytetrack-tracking-support-plan.md), not
-# carried forward unmeasured. A 3x2x2 grid (lost_track_buffer in
-# {30,60,120}, minimum_consecutive_frames in {1,3}, track_activation_threshold
-# in {0.1,0.3}) was run against rf-detr's and yolo's real detections
-# independently; both converged on the identical optimum
-# (lost_track_buffer=30, minimum_consecutive_frames=1,
-# track_activation_threshold=0.3) -- rf-detr: MOTA 0.397->0.400, IDF1
-# 0.373->0.389; yolo: MOTA 0.359->0.371, IDF1 0.313->0.354 vs. the prior
-# unmeasured 60/1/0.1 defaults. That two independently-swept detectors landed
-# on the same optimum suggests it's primarily a property of this scene's
-# density, not detector-specific -- a lower lost_track_buffer and higher
-# track_activation_threshold both reduce identity confusion in this crowded
-# a scene (holding a lost track too long, or accepting low-confidence
-# detections, both increase the chance of associating the wrong nearby
-# particle). Not independently swept for lodestar/trackpy given time
-# constraints; applied here too as the best available evidence rather than
-# guessing, matching this file's own adaptive_stop/adaptive_step precedent
-# for values carried across models without per-model measurement.
+# docs/plans/2026-08-18-001-feat-bytetrack-tracking-support-plan.md) for all
+# four detectors independently, not carried forward unmeasured. A 3x2x2 grid
+# (lost_track_buffer in {30,60,120}, minimum_consecutive_frames in {1,3},
+# track_activation_threshold in {0.1,0.3}) was run against each detector's
+# real detections.
+#
+# rf-detr and yolo converged on the identical optimum (lost_track_buffer=30,
+# minimum_consecutive_frames=1, track_activation_threshold=0.3) --
+# rf-detr: MOTA 0.397->0.400, IDF1 0.373->0.389; yolo: MOTA 0.359->0.371,
+# IDF1 0.313->0.354 vs. the prior unmeasured 60/1/0.1 defaults.
+#
+# lodestar and trackpy instead converged on minimum_consecutive_frames=3, not
+# 1 -- the opposite of rf-detr/yolo's optimum. trackpy: MOTA 0.135->0.165,
+# IDF1 0.306->0.315 (mcf=1 -> mcf=3, lost_track_buffer=30 in both). lodestar:
+# MOTA -0.680->-0.566, IDF1 0.034->0.035 (still deeply negative either way --
+# lodestar's own detection quality, F1~0.10, is the bottleneck, not tracker
+# tuning -- but mcf=3 is measurably, consistently better across every
+# lost_track_buffer value tried, so it's still the honest value to report).
+# track_activation_threshold made no measured difference for either detector
+# (0.1 and 0.3 tied exactly at every lost_track_buffer/mcf combination) --
+# kept at 0.3 for consistency with rf-detr/yolo since the sweep gives no
+# reason to differ.
+#
+# The mcf divergence tracks each detector's own raw detection density:
+# rf-detr/yolo run 900-1500 detections/frame (high-confidence, box-based,
+# internal NMS); lodestar/trackpy run closer to 1100-1250/frame but with far
+# noisier per-frame confidence (lodestar's F1~0.10; trackpy is a classical
+# brightness threshold with no learned confidence at all). Requiring 3
+# consecutive frames before confirming a track filters more of that noise
+# before it can start a spurious identity than 1 frame does, at the cost of
+# slightly later track confirmation -- a tradeoff that pays off for noisier
+# detectors but not for rf-detr/yolo's already-clean detections (where the
+# extra 2-frame lag just delays legitimate track starts for no filtering
+# benefit).
 
 rf-detr:
   search_range: 25
@@ -68,7 +84,7 @@ lodestar:
   adaptive_stop: 12
   adaptive_step: 0.95
   lost_track_buffer: 30
-  minimum_consecutive_frames: 1
+  minimum_consecutive_frames: 3
   track_activation_threshold: 0.3
 
 # search_range/memory/adaptive_stop/adaptive_step started from rf-detr's
@@ -112,5 +128,5 @@ trackpy:
   adaptive_stop: 12
   adaptive_step: 0.95
   lost_track_buffer: 30
-  minimum_consecutive_frames: 1
+  minimum_consecutive_frames: 3
   track_activation_threshold: 0.3

--- a/trackers-common/uv.lock
+++ b/trackers-common/uv.lock
@@ -14,6 +14,188 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "av"
+version = "18.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/f4/f22114d30d3435e38c6af2b4870f37b864403dca6ae7af747a289ce0a18e/av-18.1.0.tar.gz", hash = "sha256:47bfc286e1bc9de7ab4681fc2b575cd2460a66919d31ffe1bd5aa54fae531a28", size = 4451061, upload-time = "2026-08-12T22:28:18.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/d4/d7cdc8bff143c17a6d35924375ae28dd692cacde38700a7d419fde54f44a/av-18.1.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ae75d8bb6467895ed1f8572ededf7ffa49eac07f6e483222f5d7d62a41d12f04", size = 22546147, upload-time = "2026-08-12T22:27:11.851Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c9/37a619297492256b77d5ed906e7d8166c10a26ed251dccf1ae03ab19bff6/av-18.1.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:b30a4e8d934558e19602b68998a4d9ac9f250fa0dacef216f7e8e40153b13316", size = 18217603, upload-time = "2026-08-12T22:27:14.713Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/84/2464ffb64c08c5ce8b522c8e74594714414e3b0575267652c5c51c0574b9/av-18.1.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6fc837cc51adf80331ac850779cd53b5d4c4460b0ebe9057a02a921c6736f19d", size = 33640142, upload-time = "2026-08-12T22:27:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/204dbfc3e08eb4cdc6e6ff57be02150bc44523ebdb50182d10025792ebd9/av-18.1.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8a032e8d8ebc73dec079364b9b4a6837638a2d106e8472314e685ffbf163e700", size = 35786210, upload-time = "2026-08-12T22:27:20.984Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/99/b0d04ec553ff9a7e00455458dfa3a39c8a8f627b273056b4e5fe57d590de/av-18.1.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:3c8b1f8b46f99d52e2d8b0ed5d0cdadf172d24794d46e2077b16e44ed08e26ff", size = 39379798, upload-time = "2026-08-12T22:27:24.432Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b1/e00d4feae59160149df6126585e726fdc6300798fd40c5dd324879e81f68/av-18.1.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ab5ac081bc9eaf54109120d4e56284674fecfbe520d9aa1707c7fa911ec5f4d2", size = 34690321, upload-time = "2026-08-12T22:27:27.769Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/836fa987e3084d11a21489f11357fb24843ef3aa8faf74ddddfc603d5062/av-18.1.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:191224788d87af06c31784a395bb73f14b72f33d7f4871ace0157de2abdc6276", size = 36859932, upload-time = "2026-08-12T22:27:31.403Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b4/76ba21e46704f632004276b85289a1582e95f5eff760436d6149875a1881/av-18.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:ea1480b7a8d5405cb5f382b344731bf125fd2c1c6fae3964f6c48595628387ff", size = 27595679, upload-time = "2026-08-12T22:27:35.177Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ad/a3135884c5753b09773176b97201ae602f67ad14206c395ff838d66bf9b0/av-18.1.0-cp311-abi3-win_arm64.whl", hash = "sha256:5509ec12aaa19fd6601de13cfa6f4cdad450da07982118510592875d970454d6", size = 20257584, upload-time = "2026-08-12T22:27:38.472Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5b/4a756265d7fb164336c8d377bca21c39cfa2c178be23cedee840a69b59c5/av-18.1.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:b36b0bae9e4c62f9487c99481ec15e4e3870fcc868522cd6d18fc2d6bfa04f01", size = 22795654, upload-time = "2026-08-12T22:27:42.016Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/cc/1bc841462114a1adf4f7d87456ab78a6972e23271e71865fcd2bbd0e7360/av-18.1.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:025f84494cb23278498f03b0d8117d3e47a1cbc9c44b97eb31875cf02251e46b", size = 18435735, upload-time = "2026-08-12T22:27:45.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/20/005500ed17a2e62a5e4bb94aa3786942560ec2f55ec1895ebf174c87abef/av-18.1.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:08a9ae288299cfcbf739dba4ad0c53b9b71f45184303dd45947920d022fed695", size = 37090807, upload-time = "2026-08-12T22:27:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/f7/11e7f6d848d3690c31ca4f8578167393e619177f1493ccc93b9400852d4e/av-18.1.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cf8a17466bef07765dbdecc9e66ed9b25d20b4e14f654fbf35345a58ac45fa0c", size = 38976836, upload-time = "2026-08-12T22:27:54.565Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/b271473b24e806062d31191e40c6d65545e9cf59f80f044eba56dcbba0f4/av-18.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d49a5c542dfdc00f43c6cdb6cc41dac1781ee206fe180b56aa7433dfa816dfae", size = 40896630, upload-time = "2026-08-12T22:27:59.118Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/9f/2ab7fa292a947ad3466ed8e655eefa3b82f535d7ea598c297b4471a937c4/av-18.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5548b79e2bf1f59b3e9aedc918a72d9dc45b9adaac10ff9470d5dbdda0002e47", size = 37895673, upload-time = "2026-08-12T22:28:03.98Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/04507c57249b399c3e4f23f01d221532f357338b5316fd2858fbd343127d/av-18.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7ea063f6690193ea335a1d592d6e0274350d45e2ed6af83ee107cb90cbfd84f", size = 39992431, upload-time = "2026-08-12T22:28:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d6/bc4b95bea9c2353a7e4d62a3fcfad9adcf0f881741c6ce01ee179d539ce3/av-18.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e4d48b9f12cad009cc72fe4f4099107de5e819c95f82767f4fd01a01481c0661", size = 28497798, upload-time = "2026-08-12T22:28:13.003Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d2/0c277a46f12647c1833f40496e132fb6001e0d19e6144b5ea30896461feb/av-18.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5cd9085028902c9880622bd37a12fd4b33060f06a52311f6f4867ca9f29a2c3b", size = 21421979, upload-time = "2026-08-12T22:28:16.48Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/b6/034f6802e9c3f6418966cfabb7db8c9252cc2429c5098f41cc43af804149/charset_normalizer-3.5.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:eda059b6bc8bc0812d626fd91a7ce01bf583df0a61296eff390fd94141a34e30", size = 363585, upload-time = "2026-08-15T08:16:46.646Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fa/6a7e2a7c4b5451912b8c417732df79574354443592a88d616de03da66ae5/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa2bb0b37202dca27175591f761108b5d34096ade1191ffe4808bdf6b1571488", size = 251189, upload-time = "2026-08-15T08:16:48.287Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c8/ab42b07cfd82e919f427fcfaa7c41abae8242833ad1aad66d42bae40b669/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b2b1b3fa5670c127b246df1d0c059defd41f689a868a3b9d79df9b1cac42d22", size = 239724, upload-time = "2026-08-15T08:16:49.67Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/80/b9348b5d3041209f98b4cdad7655766369233f1d533f4f4f7558e9717bec/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6e5e4d73d588ca5ed09df1b7dcd1b203d1df3c542e3f50d126c947d432b10731", size = 280078, upload-time = "2026-08-15T08:16:51.228Z" },
+    { url = "https://files.pythonhosted.org/packages/82/38/083a24028304bc85bb9e376fed801178423dcbb67495f73b6ea0624e1894/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b54e7e13267d49ffbfe68e25b3cbd774dab38fa37238f71265e91b36146eb21c", size = 276650, upload-time = "2026-08-15T08:16:52.625Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/35/731ac04aa0a097fc1c97f0994c375bdb230c6c96619db794208fe664e9ce/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7b742bf31c88566b4bb6335a7f393bb322e580b6bb98df7bd0c25e6e3519ce8", size = 262325, upload-time = "2026-08-15T08:16:54.085Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/28/c2028e7021fb89c6e56868ed0e387b8e9aa811abdd2ab3208d6578d2c930/charset_normalizer-3.5.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6ba32c4d2abf1d2fe7cf27d280f4cca5664233b0f885549c7761719eb977f486", size = 261140, upload-time = "2026-08-15T08:16:55.604Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f0/0c0ceec6d98b7daa62e361e418135d59685811d79ba11529aad5cdf15e84/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0722590aabf9dc6a6c0343d523c05458fa2b5047dbe6302fd526bb570600753f", size = 252791, upload-time = "2026-08-15T08:16:57.103Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3e/48f4cd187b1c33189d86039e9cbe4f92c05454175504b44ff81806d4d1bf/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:aa1099b956fb795e686d073568f6dc002a0bb89765ea6d5b055dd7d9bf1b116c", size = 240730, upload-time = "2026-08-15T08:16:58.418Z" },
+    { url = "https://files.pythonhosted.org/packages/42/85/f9e22af69af67c54cce42be9455d9c81294f918b4ccc454db01f66efcac2/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bd6c173f04743d483881bffa1478d5a4624475b8cd1d2194956a75548e191c18", size = 280791, upload-time = "2026-08-15T08:16:59.918Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4c/9044135f42127630b6fa742feb51256353f6ab87a78f2fdd1de3de955a7f/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:f298e218441525d3794428b4c8b8fb8662c6d3ea79925d4807ee6b9a96a3bca5", size = 259598, upload-time = "2026-08-15T08:17:01.421Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ed/1dd7cfebb4e75812934c49ca3b79757d11948053f7937ab7070c151f3c55/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:6e2912d4babbc65196ac13c2f53468dc57fb8b9c25ef913e8c59ddf7c6dc0e1b", size = 278217, upload-time = "2026-08-15T08:17:02.782Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/eb/239c84503cc9e3ba6eb34686a24bc66e84f3924efdd7e38e751a19f6bc10/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3d27167433c0d5f18dc850f07d0b3816221984fecdc405d6c157a6f0b8f8e9e6", size = 263417, upload-time = "2026-08-15T08:17:04.216Z" },
+    { url = "https://files.pythonhosted.org/packages/37/ab/4e4510e1e288478e2c8333131d1c1382382ba8cd2165053c79e39d1da961/charset_normalizer-3.5.1-cp311-cp311-win32.whl", hash = "sha256:ac00177c4831ffa650f8609e4bdddd5fe09c03b1c0c47acece7e6ea20421598b", size = 181774, upload-time = "2026-08-15T08:17:05.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/57/32f0ccea59e8612057c61d6fd22ef2cb63cca93c9fe594094919696ac170/charset_normalizer-3.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:f9b1e28d0e8dbfa858abdba91d6b547beaf2df1a59bec6da6faae7b96a4991a9", size = 206653, upload-time = "2026-08-15T08:17:07.075Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d4/b65c433fc521e58b5f54293982a5e51c05cb5f2dd3f1c7a6acb65b75324e/charset_normalizer-3.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:ae31a1a1db2ee6cc2942fccaf695c934bc7f3db9f2133a3fef1f367cf1a4ab10", size = 185630, upload-time = "2026-08-15T08:17:08.502Z" },
+    { url = "https://files.pythonhosted.org/packages/30/27/78873dc8b6a56357517b74b6bb9568b80450e7bb4f6ef7e3fa9d22aa0bd7/charset_normalizer-3.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b6d1386bf0096d26d3a863dc0a487a5b4eb9aa93cf5ba69683d29dde6b9d60f", size = 344456, upload-time = "2026-08-15T08:17:10.072Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4c/be49ada26b1f0232d57aa89bbebf997a5cc2332a5616b6eca26ff680044d/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4582c27e8c889d64811987b5967fbd3ae0c823fe1fd933b543d55ac20bb475fa", size = 238530, upload-time = "2026-08-15T08:17:11.563Z" },
+    { url = "https://files.pythonhosted.org/packages/76/84/6f1290fa07ae6978d3960caa3eb1b8019bf9284ab7c2297b00c099ef4250/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1d1c7a53a6c2103925cdd6d7229f8c567379f211c869793df679f2e9f738c369", size = 230200, upload-time = "2026-08-15T08:17:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a0/47b18adeed31c8f16ba9700f32c1b18594cfa09f47eb672a488c273c22bf/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e6621fb2a4988d6e53eedc455e5903e2679f3967b8acb3d639f1b63c14a2e893", size = 262222, upload-time = "2026-08-15T08:17:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fe/341861ac118dae06f3ec0eb487488af52128f2ef2faf0b11003944d22259/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c0c10730342b0c9b35dd1d619beb8214e520bd96a1f870f452680b238aab3e0", size = 258951, upload-time = "2026-08-15T08:17:16.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08", size = 248801, upload-time = "2026-08-15T08:17:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ba/ef83ae3aca816393decfa3530976f38a79812d707b80b580ac33b83f9877/charset_normalizer-3.5.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9f8405c2c758532c74fed975dbee57be1f31a6e865c031870c79a6ed3212ada", size = 244070, upload-time = "2026-08-15T08:17:19.191Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0b/c5292a2462d69b7378ea89793bbb5b2b6fcf6f7dd6d1667f9619094ad553/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:96fef3e886d6a9874b14f27fc193fbdc69d5d8035783d86aa4e1cea594e695f9", size = 240110, upload-time = "2026-08-15T08:17:20.547Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/111e5be3b740d5c2a5bfcedb3d237b6591e5c2e82ae9d6ffcb121fe0909c/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5d8531a6569d025f68e2321e7638fb7978f23db58e5f69f56913837aae03816e", size = 232836, upload-time = "2026-08-15T08:17:21.895Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d2/d2aad6fe0dbb44b194bf3becb60f5a0ac48446ade999a47fe7bb41eb09a7/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:aae2ee51122d3ae968a3837d97dc24a0aeebb0dea23694422cd172bd30017cd6", size = 262712, upload-time = "2026-08-15T08:17:23.727Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5a/337e4663a5eae6de99db940ee8066d4145caafb61327db62deda15313cce/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7235dc28fc6dd9d832ac7c7bce95367dedb85929f17368a0c2bee1e080b9acbf", size = 242977, upload-time = "2026-08-15T08:17:25.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/85/f82f8a92e31c7519410e2e1afdc630f28ec47490ce2c09a11c1a43cbb459/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4abdc5f9ad448c1ecbfae2974b820535d6bc6e7eef63babbab3d81cf46968c71", size = 260207, upload-time = "2026-08-15T08:17:26.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/52/643d11ffd60e9ac2fd1fb87e167a19285b9eefeff4a40e63c87cbfbeab36/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba501e667c17d8411f98e67a022d9604ef179aff0e459b7e292c796837c13573", size = 250562, upload-time = "2026-08-15T08:17:27.971Z" },
+    { url = "https://files.pythonhosted.org/packages/62/16/46556278c2168d12df9da7fede5dc6fc70e60301b26a82bbeec238c9cfe3/charset_normalizer-3.5.1-cp312-cp312-win32.whl", hash = "sha256:cfa1c0cc3a8f9f53f1243a5a99ac36fd003880199383b37672e86ddda9cb07e2", size = 178507, upload-time = "2026-08-15T08:17:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/4c6c298171e6b3e745633180ff59350fc0ca0db1ffd28df1e369e0579f71/charset_normalizer-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3617ac3cfd8b9888f145ad89dd6e692285834b0201c6074a5eeaad3fd4d668c2", size = 200551, upload-time = "2026-08-15T08:17:30.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d7/eb95a042f0dd22e304b0b6472b154f3546a1a039a9ee89ccb2a7f61591fc/charset_normalizer-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:88e85ab89cb822c1e635f51d6d32e488f94e002e70e2f492bdb8b945543f345a", size = 180700, upload-time = "2026-08-15T08:17:32.028Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/61/2cb6ad133dbbb449fa2d37ccae973232f4827e799af258d15e589a3d1e9e/charset_normalizer-3.5.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:4f298bdadb8f0b9e5672877f647d1be9373ef5320c9e2f049795e26cad28b6a9", size = 211584, upload-time = "2026-08-15T08:17:33.597Z" },
+    { url = "https://files.pythonhosted.org/packages/18/57/a305c968be1ca13f3dd1b32f445877e97addf55d80b65c7cb35fac82b777/charset_normalizer-3.5.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:88ca277405c2d3b71c4e1c2ee0e7966e807bcba86a69d11e19ba199d18ae4491", size = 223359, upload-time = "2026-08-15T08:17:35.022Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/d3646670292ce8d8f8cc11ac067d44885e697a5591f57a9221128da5e7b3/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9362dd90aa7dab48c0054a21187791ccf05473f7dba5d92b8033ae62164675e7", size = 194464, upload-time = "2026-08-15T08:17:36.452Z" },
+    { url = "https://files.pythonhosted.org/packages/de/93/d51ec556e01042fed6f993ea859311bc7917b466684182fbbceb6ca24762/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:977cdbd483a9cff38179bea4fd754289a6f2195c7abd414aba85410b3e66cc5e", size = 197676, upload-time = "2026-08-15T08:17:37.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a0/562247944386f7d4ef94467e84876600cc1e0f1b93239aaa9213d2bc3cbd/charset_normalizer-3.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e90251c0c7bdd54a100a0dce3c07b7e637278c93af29dbf78ebb89a58c4bac7d", size = 340473, upload-time = "2026-08-15T08:17:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e7/1d994be1b93d41e9502b8b0460eaa88a1dd8df335df415db87d6c3e91ab2/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94d78ecec2605a8d0398b0f365d5f12a63248438516f5dac536a5eff7337df4a", size = 240156, upload-time = "2026-08-15T08:17:40.66Z" },
+    { url = "https://files.pythonhosted.org/packages/09/53/27923ce5cc6cbccb832037b27dca98882d9c53e9b69e866bbbef4aae7fc8/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d59b75732e9b6f27388e10c14b0259cc5f2e48c78627d185e6a177b58ad3cffe", size = 228246, upload-time = "2026-08-15T08:17:42.003Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5a97e84d63af1d55c07439cb80e56d99a8efb4295700eb4e18c0d1615d2c/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0d929fc574b4d6fd9e7c0f5c2ede8716a41911923aa7fa5fce38e0818aa4a1ac", size = 263660, upload-time = "2026-08-15T08:17:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/071575791dcc88316c0a9a65ce38897a82e4cfe4a325f0f7fe1b1ac47bcf/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:394fea06235c8543390050ed5f529187074b029fb027213f6c46ac11ab5d950e", size = 260354, upload-time = "2026-08-15T08:17:45.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3", size = 250638, upload-time = "2026-08-15T08:17:46.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/66/70dfad64f15be09c15ccfee81330a7e515895dbe296dd23114e9a231268a/charset_normalizer-3.5.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa48b1b63d639f9483e0633e092f5851e2348c352f1f9bb6c8182f87884ef876", size = 244583, upload-time = "2026-08-15T08:17:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/24/ef36367d38b9ddd4bccbf72888c342e8de1f5ae506fa0b2dcf970e2732a1/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c71fb0d56c920c269cd3e2e3fe7c610e3f1fdb21a6ce60efa6430ff63676cea6", size = 242038, upload-time = "2026-08-15T08:17:49.481Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ab/55e683ba0fff2e43adafc10daa3001eac90fdaa419a97227d5a7067eedde/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:485a0d363cafefcd2538a73c7c838daa2035f09b2c9f9b5e3133f80c6aeb84c2", size = 233677, upload-time = "2026-08-15T08:17:50.845Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/67/0f40eaf8d1b6e7cf15e82382a2965efaca787fc1c2794b7021d37aaf5036/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0ea61a470e070686aa30892fed79e297d2c8d0ab46b8bcdf027d38c51da591", size = 264491, upload-time = "2026-08-15T08:17:52.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/64/12b4c2a11ee8df4fcc518c78b0d93e3a92bd3d5253d1617ce74ff0e8c7ef/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90b7481fb62fbe172c558bc6fd1c4c98d82004a54a7551f20e11ac9bf0b8708c", size = 245196, upload-time = "2026-08-15T08:17:54.023Z" },
+    { url = "https://files.pythonhosted.org/packages/37/2e/651d910af6d0fba325eee1cda37ec5443462ed25360e666c144166eb6091/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:35fe081843b35aad20ffeccec3eeffbe637b15d14f3fb22cc1b59cd8ec17e93c", size = 261660, upload-time = "2026-08-15T08:17:55.491Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c6/b09e05e6db7f64338e0dc067c79577b1138da86c1e38369096851d96be88/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd0350afdc3aabd5576f60ea109228bd5538139713c7b094c5cd27c73a98bc6f", size = 252618, upload-time = "2026-08-15T08:17:57.025Z" },
+    { url = "https://files.pythonhosted.org/packages/76/4e/362d4f9fdcdf5556fb2aa3ce7d4a58ebce03ed1ff03aa1d9aca8d02f13f3/charset_normalizer-3.5.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:9d9a0dc7cbe9bec24c3f767c9122c41fe5a1bc43f47cd099d00d393e09769de4", size = 140362, upload-time = "2026-08-15T08:17:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d4/703be739b26acce318bd29eb3b25b7209e1b1f527f9eae3d1f1f01fdde2b/charset_normalizer-3.5.1-cp313-cp313-win32.whl", hash = "sha256:d63600d620ad0064c3a748b950ac5ea38a80190e5498532efefa4b7b3f1da1f3", size = 177755, upload-time = "2026-08-15T08:18:00.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/56d97ade41c8db611e727168c52ae46c9224c362ec28d4b65d7e9869e8da/charset_normalizer-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:aea996a6aba25260827c9ea511d1addfde2da9eb686ac961838509086188b7e6", size = 199295, upload-time = "2026-08-15T08:18:01.506Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/75/5b20dd1e6573a01a08158fe104104fa2c8abf941745596954185726cd46c/charset_normalizer-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:fd0a274c0e5f9a21565cd9d3dd749b61f96b7aa1e20a93aa1ba4029518f2e5c0", size = 179856, upload-time = "2026-08-15T08:18:02.929Z" },
+    { url = "https://files.pythonhosted.org/packages/29/cd/2b812ce5e888f1ce69a5350281e58aab07ae64a958ecae8912f30865718e/charset_normalizer-3.5.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:774d157f112367ff4abd29019f38f023c24e00e56edc7829c20e358a5a913ad8", size = 212318, upload-time = "2026-08-15T08:18:04.403Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/a6ee107430768a5334e6d63f31f148a04a1a491ef161a1ac9415a73f2fa8/charset_normalizer-3.5.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:26422d45fd13551cf564c58932f7d72b4f58b93b0fcf18c35ba6be12b46bb102", size = 224897, upload-time = "2026-08-15T08:18:05.997Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/35ae3f64f29d0179c35c3baefe575904df2913dde519129c7f75995a2b1d/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:09a7bba9f739468c8e78c36a75c33768e53cb1959fc638f510454c14683f00d5", size = 194848, upload-time = "2026-08-15T08:18:07.397Z" },
+    { url = "https://files.pythonhosted.org/packages/74/76/f2fc7380f056cc273a53af37f50d08ad54b2c59f61078f31432edcf1c2bd/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4c9548dc78002099910abaebc0a72ac58b7d30931869e0351c09b507dff4ece3", size = 198163, upload-time = "2026-08-15T08:18:08.989Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/40/095ce62fa078483cccc1fa2b36e6bc9580b85422a20ee9f925341c50e44f/charset_normalizer-3.5.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c428c6c31eb5f4277d7f8eccaf767fbd548ddd5ce3c8b4f4cbbfab3d96b5904c", size = 341823, upload-time = "2026-08-15T08:18:10.458Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/5a/0e58b1c04a1596e0256f407274a92d5fb2ee21324409d1fab1da48a65b5b/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f06b7eae9dbe77fe1d644ca244dad508de8d302870a43f3c559b521270938a0", size = 242458, upload-time = "2026-08-15T08:18:11.989Z" },
+    { url = "https://files.pythonhosted.org/packages/22/95/b4618ce912e6db0b1aae89ba788e38e8a7eba0f3025cc66e8c0699f977b2/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b7430cf5728e68f6c462254009a6ef4086e1bea43cf2f57aa9c55fb4f50ff96", size = 226717, upload-time = "2026-08-15T08:18:13.401Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/76/c681192bbda3d55356db5dadd64381d5202b37c6b598fcda5282e88b5d3d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab743e9bc90c1f73552ec33e10e3331315acd2c397b36065b591b0181de533cc", size = 266111, upload-time = "2026-08-15T08:18:14.961Z" },
+    { url = "https://files.pythonhosted.org/packages/88/be/55127bfca72c0cff6c022488d140d7c5b04c771e3b72e9bdb4836d54979d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6f7deae3feb4edfa2efaf7c574fe88cbf055038a6abdb40188e4fff66d5699f", size = 263128, upload-time = "2026-08-15T08:18:16.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/91/39c3af510b0aa32bbda03374259200f28430febfd1bf5e511fe765282ce5/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15f024313246a4ed976c60f440bb8d257815513a681d212ff74fd46f7d715a90", size = 251240, upload-time = "2026-08-15T08:18:18.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a5/cbe418bbc6ecdfc3e05a0116002897c4b403a5e838d697e64c78e9f0190d/charset_normalizer-3.5.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:823f82903d189af463d7df250ef1f7f696f3cee08cc8d91deb565e8d425f6506", size = 245282, upload-time = "2026-08-15T08:18:19.625Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a4/689bb42e8e7cd492f3cb64907c6bc00ad247ec9a3628cd3f8eed126e8ae1/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:01e93745f7f219b703b60ba7afead36cfc4242782be5af484673fc500df12da5", size = 244597, upload-time = "2026-08-15T08:18:21.121Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ce/9962938e179cf9f699d3f1e7b3114b5d7642dee6a893745229f9dd04f274/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329fc3ccb63ad22d867d84c2adea759a64079a37ba4a343433b02c7a2816871e", size = 231376, upload-time = "2026-08-15T08:18:22.57Z" },
+    { url = "https://files.pythonhosted.org/packages/85/54/46000450ada53bd9eac5429a2c8c54cd2d9b39c0c255f229aea9af0948a5/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:bb57753e36e4855b8ca375069482250a6246372331a3e4f3407eaebb007443f5", size = 266715, upload-time = "2026-08-15T08:18:24.235Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/bb/618749d70f792b44252a777bf89bfb86823b9bbc1ea13fe8ce759b07f38a/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fce8cbd4997efeb450bd298b54f755dcdff18d496f7a5ddbb4867c6d7c88fdc3", size = 245848, upload-time = "2026-08-15T08:18:25.726Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3f/ffb64458527c7668031d5eb095d978de561958dc9f5b53f8e488a533e603/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6c9cdde8becb25a7fde49924511aa2644d6f8081cc8df8e9452724303348d8e3", size = 264521, upload-time = "2026-08-15T08:18:27.193Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ab/74a55fd803916a35ac461daf002708191aac19b546b80dc8cabfedc63d98/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9ac4444d8d4fd4c4bd08bf451ed3167aa9e7ec6cdb41b648794f1d1103652e36", size = 253054, upload-time = "2026-08-15T08:18:28.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2a/6a9034b7d3c60b17499afb482df5878bf9fa20b50cc3887d5ef017a833db/charset_normalizer-3.5.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:f03ac127268b43ef4fe9e6ab6794a6794b49485a0cc0c1db79876d2f33f75bc7", size = 140580, upload-time = "2026-08-15T08:18:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/46/1d362e1a00d035d66b9869e1281eee115907f7e390a16a07824ab5737360/charset_normalizer-3.5.1-cp314-cp314-win32.whl", hash = "sha256:1f5883d77fd409a261abb5dc8ccbe335720d798b1de4abb3b1d47ccbbc76b53b", size = 180325, upload-time = "2026-08-15T08:18:31.877Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7c/4938c329b6a9d446f6a59aa2092ff7118f274209b5ed0e26893d1d30a63c/charset_normalizer-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:c658c50ac0c98cd755a2dd50b7977d3bca7df401dcc47fbdfa87db53ef7d4e8b", size = 204175, upload-time = "2026-08-15T08:18:33.466Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/33/eeb384dbd8dec570661354592f4f2e1b2fcc92585624d146a000caf53841/charset_normalizer-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:4bea7f8ebe90bbd7f0e4a2de42ca6924ba23e3e76418c408ff82f1d46fabd687", size = 184123, upload-time = "2026-08-15T08:18:34.913Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/6c/c73fa9d5a85f6ab05395de61c5f6984e0a9ff40bb5ff888d46dff02526c6/charset_normalizer-3.5.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fbc597639158fd7c14d55e808718848319540f51b0e6746e3eefa59723a4a348", size = 381682, upload-time = "2026-08-15T08:18:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c7/63565f860921457feba93bae6c86fb7746deb4cffeed2f375cb845318146/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e71c909f353863b2b89c83de2ebed71ea6d0df8a6ef65a128193c5e650766bef", size = 240826, upload-time = "2026-08-15T08:18:37.887Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ae/7ae8807410dfa33f8e6f1715740adeaafa8a816cc4cb33508f54b1f7c896/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7ac76cf9afd34929d76eb7fcb63be476a4853d8a96f0dcf2d0db68a0cbdf9885", size = 227861, upload-time = "2026-08-15T08:18:39.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a3/887c1642f0da26000b0e0652d91071113c0e72cea33952e225cf589f49a9/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a3a370082ce34d0612f421e15fe011c53bb1feff21a26d06ad4fb244dab5a375", size = 260758, upload-time = "2026-08-15T08:18:40.88Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/e6f5b9a3d0e55b0ef7505cd3765cdd48f22db89994c947b316f52f801fd8/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:256dd4d85d9e4dc595e2bc983c980e73f62ddeb3165c58b4c3dfe78c5c8548c1", size = 259950, upload-time = "2026-08-15T08:18:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ee/e4e10a94d51cd1ee638aa7e00b65399e6b2a4e8376ab6d2eac9f95586671/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58d4aa13a59c969dbfdf9e6a9560e242cbfd9e8a8f50c2747714df1a423adf65", size = 249329, upload-time = "2026-08-15T08:18:43.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/25/d5f4198819e6059735a84e8d0bfb72dc33976da67b97adcd3fb5a5e07ec6/charset_normalizer-3.5.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0c6dfb5ca6723eeed15aa8e564a014d69fcb8812f94eef11fe3631e0508199f5", size = 243137, upload-time = "2026-08-15T08:18:45.368Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e925ca7569cf9fb9701fd82503fee73eea5268fdb856bdd64947092d3daa/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c010f5581d9c612804cc59fcf7b524b707fbcb72828551237ab545bb5c7034af", size = 242820, upload-time = "2026-08-15T08:18:46.842Z" },
+    { url = "https://files.pythonhosted.org/packages/34/17/672c251a888ed2aebcdd2fe830ad0104e25ff83c43f5c4f9c15e9fc6853c/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:52ec005752a56ae79547a05c0139ca2501a0c866390b6115008456b9f0e7cde1", size = 230504, upload-time = "2026-08-15T08:18:48.353Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/fc/f6a85abebd42ce4da2f1db0aa56cc6a0df1995e318b3875d14401b8381d1/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2bced4061f000f7187254a02ad3433ae17eaf991747ceea2f478422590a5bba9", size = 263087, upload-time = "2026-08-15T08:18:49.859Z" },
+    { url = "https://files.pythonhosted.org/packages/98/66/7c42677e739ba66746b297e2046918d793078094dc239e1e72768cffccc6/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9eea3ab2597a5e65fe65296e2d6a84570845a6b55532d90333d740d48bbc850a", size = 243269, upload-time = "2026-08-15T08:18:51.601Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d8/a50b79237f417af10f8c2a501ce8d1ca87829a22e69117891ca4ba20a69e/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:496846868fea80e479324862fa877f02411f2fd0f83b79ccee2607aa68b2a032", size = 258766, upload-time = "2026-08-15T08:18:53.23Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1d/0fc91aeaeb3c83b748f532399ce67cf84604b48297405d740000f7a9e786/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:85d5855daafc240cc045c026d7a15fd198a09b0fc8ff6f5ecbb5297b509cb11e", size = 250814, upload-time = "2026-08-15T08:18:54.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/10/3d8c777cf9024615295aa1b808324ad5b4a77855869c00824bad74ffaf8a/charset_normalizer-3.5.1-cp314-cp314t-win32.whl", hash = "sha256:58d3e12c88e0950bca850ae1f7c256055c097639c2edb9eb123af9807d8b15e4", size = 191074, upload-time = "2026-08-15T08:18:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/81/ae557d3c44d1a1d688696d60563413a0866a91b7ebc50f20df838be3d8c8/charset_normalizer-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:acaf604462bf330b0d07e7a07c1d6e4adac79e5fb13e9c5140590542cafacc00", size = 216476, upload-time = "2026-08-15T08:18:57.889Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e9/61c01fb8b804692569c036b3fc50495814502dcf13a60649c6055390b02c/charset_normalizer-3.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:fdb8a068947befafba9952162645dc2fecaeb400e64584829ed5e9b2fbe21a7f", size = 194115, upload-time = "2026-08-15T08:18:59.418Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4e/8544831ef59d8f27ce92c80871380fdacc8076a8a56ed62f82e54f991333/charset_normalizer-3.5.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9085f87b0e38a2b92b8923059b4e8789fe40d9279712d15dcc670048d77079af", size = 342048, upload-time = "2026-08-15T08:19:01.054Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a6/e3b46852424246065355644f4fb6dbccc0239a42a2eee27ecfc8957f0bcd/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2679de311c7946dde5d3b6f44941844133ff5c7cb86099c0061ab1e8901c20a8", size = 242997, upload-time = "2026-08-15T08:19:02.492Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3b/0cc9a26777334ab2f2e3089b948bbf4e4fe72ea70b897715ef6415043ec8/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:baf3775a2635e5a11fbd5e4e64ee69c7e86875d224a5c72aca4c141064589a90", size = 237014, upload-time = "2026-08-15T08:19:03.943Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c2/027335f0aa337a2a2e121bac1ad88c4f02ba6053ea0926802784f3db11af/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac8c94b6539074e0f40899301273ac8402b9b3e01c7b7ba269ff30340aaaf20", size = 266174, upload-time = "2026-08-15T08:19:05.598Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d3/e367787febe4e74769dec0f406f2c3c8d1b955fce5aee1fd0f94e8367a45/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8fe532b3c966d1fb794e0698e4589d0444017ae77fc0b31edea13c0e35bcc449", size = 263361, upload-time = "2026-08-15T08:19:07.251Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3d/391b193eb9f3e84b02f9314088c386debdc0debee843535aaea2e2c6715d/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c84bec0ab5ae0c64bfe73a7d2adcb5ce73b467523fc27fd6a28ab2aa6cbe35a", size = 252143, upload-time = "2026-08-15T08:19:08.816Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/57/de221f1745a90d418199761967e2776bfe2c275a1194220985e8c1d37833/charset_normalizer-3.5.1-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:854066be00447fa8de2ccbbe893e2ffc4b123ef16d897af794c1e18bd4a714b0", size = 252086, upload-time = "2026-08-15T08:19:10.255Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/d119f86a01f9331e8186175f24873b1d74a7ee9e2e4b4d68f9947dae5afd/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:21b82d8082f6f5e7f456ef0bd16323d08de1266efbfeb476e64b2a91d1471a4e", size = 245231, upload-time = "2026-08-15T08:19:11.807Z" },
+    { url = "https://files.pythonhosted.org/packages/26/de/d8e48c135ae480879539cdb179c8d3b50c7879497d75dd899b5763b69cee/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:838648accb3a7fd9803fd45c87bce8509648eb0c11bc34e216141300977244f2", size = 241546, upload-time = "2026-08-15T08:19:13.416Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c4/217755fd1abc50d326c252922cd642002758095a81ff45010337b8b3ef65/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:195ce897c6153c0700078142cf8efe3e6454ca4cf4357499e4078dfd83396626", size = 267033, upload-time = "2026-08-15T08:19:14.981Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/34d8e404e358d2adcc5a228c2134643af00104c8fb0bf525f3688d756f05/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:978eab16f55b4ab2c2a745be9a0a840bf8f09a7f227d9c76eb30214d078865a5", size = 252045, upload-time = "2026-08-15T08:19:16.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/fa/40414471acf0aa0692ca77305aa00e434fcd8288f0941c93c30e9a5f8f2f/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:cc0329df4caaceb950d2f580b5ac716a377f7059624a0bafaeaf8a218c6ed774", size = 264866, upload-time = "2026-08-15T08:19:18.101Z" },
+    { url = "https://files.pythonhosted.org/packages/32/90/fcc850bae791abd2e0c041847f13e270aa08692a79f3e00de6d2dce1cb50/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:687c9ca3035544b113bea2055e180af96fb63c0c476e22a9180f51925186e7b7", size = 253932, upload-time = "2026-08-15T08:19:19.734Z" },
+    { url = "https://files.pythonhosted.org/packages/af/af/53afe99068b3c10b4cbae592a52ef72a7c92c0188440e83ee3a078fd8f75/charset_normalizer-3.5.1-cp315-cp315-win32.whl", hash = "sha256:706bfd38730a5ac7a365793269a00f4e988178cec121391f4248d84ad8c972e9", size = 180320, upload-time = "2026-08-15T08:19:21.37Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/bc/f46a132041b29e4a8779ed712d3df1bf112e94ca8de58b66d7ec2c0cf8b9/charset_normalizer-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:92caef967d287a407085d61176fce4012b1dd62daed4eb6d5ceb26d3d2538712", size = 204174, upload-time = "2026-08-15T08:19:23.088Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5d/9ed554480eda8e447b673648628fdc29574d23dbad01fe11837adedd1cae/charset_normalizer-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:5fc45d653ea8c9a20479167e11d4a0f8cb2fa3470737ab6f9c827532313187b7", size = 184126, upload-time = "2026-08-15T08:19:24.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/32/9b8929bf384061ee1fe5d9c27c6f9776d3d824039ad4e14c88ec00c7808e/charset_normalizer-3.5.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:59171c6e45bf07d0d5cab3b0bf81d945035530f6873398b3b531c31184d46663", size = 381441, upload-time = "2026-08-15T08:19:26.038Z" },
+    { url = "https://files.pythonhosted.org/packages/96/10/e9aa7923d3ddac652c99a1c5f7be494e737e151566a44abe018daf757f2c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9dbdd9205662134957cf0c324f639bdc5031c0ca056e2369e238db75187c0f11", size = 241742, upload-time = "2026-08-15T08:19:27.532Z" },
+    { url = "https://files.pythonhosted.org/packages/28/53/a2d249ebddf47b889a100c0bdcb61a2f9dbb8bc24ef325cc062e4f476877/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e4b018dc5a0eee4676e38fe84a47a427816c590b93b55d9025274ec4d6ffc2dc", size = 235298, upload-time = "2026-08-15T08:19:29.274Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/07/469f78af590f7d5cd48e20d8dbfa3d66deeff9ba37768c04d886b5afd45c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced3fdd71aaa83ce593746c2edb42b7a59cb4c19c8b5c407781c72e493aae55a", size = 262500, upload-time = "2026-08-15T08:19:30.955Z" },
+    { url = "https://files.pythonhosted.org/packages/55/66/3bb56a47f7dcba014055b1a1d33c6f08bbe9c1e74dba154cfa25f90ae885/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:19a3dd5aa73cef1c99687c4fc57db016a9c17104ae1185da88ba566a5d3bebe4", size = 258888, upload-time = "2026-08-15T08:19:32.458Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c1/2adc2800903fb013210349313b710a5376856578d9e33e6b9a1d8b36714a/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc5d36d96478aa9c60654bd932525bf32964c62a7281eafdf16d85003a8d6004", size = 250243, upload-time = "2026-08-15T08:19:33.94Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b5/a18d0dd1157ab655cc2cb14a545f4a4784bbad70ab3502412e36097502d9/charset_normalizer-3.5.1-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:04368edf83514385ffc3e1cfd4546e595f4f1272dd23ba437a93a9cc3741d47b", size = 249871, upload-time = "2026-08-15T08:19:35.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c3/525f508cd1e58d0450ac55ed40ac75bc3a97482c59def5278456a5fbf03c/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:9b5db6052055d34d41230fb78d7c439c23dc536a9896f6cb039e8dd92cfc1263", size = 243580, upload-time = "2026-08-15T08:19:36.886Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c1/49a91fe7e97c8140094ca5c64161ab623a70d9f636bf834eace14048acb5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:252d099029bcbea642f2a06c4ed5046bdf8b5a8150b64afa5e027e88b106e5ee", size = 239807, upload-time = "2026-08-15T08:19:38.392Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/58/56a48c296601274c4689b864a8e2dfb209b81dfcb39472753ce95eea662b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:6199d5606e2bbf2b096cf64d03f8b6790c91081d5ac866b8e7bb6422738cc60c", size = 264083, upload-time = "2026-08-15T08:19:39.856Z" },
+    { url = "https://files.pythonhosted.org/packages/10/4c/dc48409274a1817ff349711d26c62aa0c597df865d4d69ef79160c859193/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:77efcff2b23071c349402ac1066667a3d011f62398d81408c9b88ad991747c9e", size = 250317, upload-time = "2026-08-15T08:19:41.53Z" },
+    { url = "https://files.pythonhosted.org/packages/81/58/d325912115caec62d6bdd77bbab5e0b7da5d234a9f20affdffcbcb530d0b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:a5cbd90ecf0fc62e64726917ad083b73001f0563657a87ec3c0b504e277dc90d", size = 258173, upload-time = "2026-08-15T08:19:43.07Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f7/b13b1ccae2c8ec63980d13be1890eb73f8aeabbfce02a24aabc0908788f5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:4d26f14f041e83dd8edfd61f4cd4fa7285d31798b5bf1f28e70c367ba6c41d61", size = 251960, upload-time = "2026-08-15T08:19:44.587Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/25/ed3f9919c5aef8cc818be1f972f565f7610d7b2076b8ebb98839516ffc3c/charset_normalizer-3.5.1-cp315-cp315t-win32.whl", hash = "sha256:ac13b004224fb341e1e25a1ed5e19d32f57cdb2a403e01f003b46f051a550f6f", size = 191186, upload-time = "2026-08-15T08:19:46.293Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/43c2b3e9d8267092b913eb8b0603f0f71993c395632886bd37a7223f96cf/charset_normalizer-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:35aea775dc2bd5f54cd84a1cd2696cc3207c479cb9cf0bd346f0d343e4300ddb", size = 215947, upload-time = "2026-08-15T08:19:47.853Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/9aad3e9c8865e5e0efa9a7f6f81c37a67635a985145ecd44528a81e088ee/charset_normalizer-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:fb78f6e7fcd8ad785d28cd577168bc1aaee827b25bb8755638f694794ea98f0a", size = 193909, upload-time = "2026-08-15T08:19:49.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -115,6 +297,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.63.0"
 source = { registry = "https://pypi.org/simple" }
@@ -161,6 +352,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/34/3b/214dcc19ee31d3d38fb5ad2755c11ef0514e5dc300bbaf41c0b69f393799/fonttools-4.63.0-cp314-cp314t-win32.whl", hash = "sha256:948428a275741f0b64b113c955425a953314f4b9ab9997f73a72c83e68e569c8", size = 2359326, upload-time = "2026-05-14T12:04:24.22Z" },
     { url = "https://files.pythonhosted.org/packages/dd/1e/3ff1a9b523058c2eeb6a9d50f5574e2a738200d0d94107d5bc4105e8da3f/fonttools-4.63.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d4741eb179121cab9eea4cb2393d24492373a260d7945006358c08cfbf45419", size = 2425829, upload-time = "2026-05-14T12:04:26.829Z" },
     { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -670,6 +870,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pydeprecate"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/c6/0f1429fc3e7a28221c31b1cba08d04a8019a3cb487661908d045f9c25318/pydeprecate-0.11.0.tar.gz", hash = "sha256:fc22d73b3c104dfbf0b318f9ed6d81fc121bfbbd13b1bdae12138757011abdf2", size = 205330, upload-time = "2026-07-17T09:36:35.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/15/e46e7c6a13fd5e0aaaf01638765b9d2b73a00db743919e4ab294a5753d1f/pydeprecate-0.11.0-py3-none-any.whl", hash = "sha256:cbd4d39d2de22a1b284c586c0daf054eba6ef7b854904d236ade49f885b21738", size = 144295, upload-time = "2026-07-17T09:36:33.499Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -771,6 +980,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -780,7 +1004,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -859,7 +1083,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -915,6 +1139,41 @@ wheels = [
 ]
 
 [[package]]
+name = "supervision"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "av" },
+    { name = "defusedxml" },
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pillow" },
+    { name = "pydeprecate" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/fc/9d772347bc30496521fd5520dee9a980e8be049f3a70400e3636528b3aa0/supervision-0.30.0.tar.gz", hash = "sha256:2289c28cde528009a82a9b0582bc5ce76d90b8645c76d0783b6b7abc3fc5c572", size = 334863, upload-time = "2026-08-04T17:37:56.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/9a/e9b30c1b7624397f2023d66771cde2bc954b81b0cfb124eb3f3c52c08c4b/supervision-0.30.0-py3-none-any.whl", hash = "sha256:5b7117f7bdfb4b890b873cf4d0521fdc0746bc48634fcc32ca534ce17d917e35", size = 373274, upload-time = "2026-08-04T17:37:54.75Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
 name = "trackers-common"
 version = "0.1.0"
 source = { editable = "." }
@@ -922,6 +1181,7 @@ dependencies = [
     { name = "motmetrics" },
     { name = "pandas" },
     { name = "pyyaml" },
+    { name = "supervision" },
     { name = "trackpy" },
 ]
 
@@ -935,6 +1195,7 @@ requires-dist = [
     { name = "motmetrics", specifier = ">=1.4.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "supervision", specifier = ">=0.21.0" },
     { name = "trackpy", specifier = ">=0.6.0" },
 ]
 
@@ -964,6 +1225,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/verification/README.md
+++ b/verification/README.md
@@ -178,12 +178,17 @@ uv run python benchmark.py \
     --ground-truth-tracks verification_output/ground_truth_tracks.csv
 ```
 
-Outputs (named per `--model-type` so a run of one model doesn't overwrite the other's results):
+Outputs (named per `--model-type` and `--tracker` so a run of one combination doesn't overwrite another's results):
 - `verification_output/accuracy_metrics_{model_type}.csv` — per-frame precision/recall/F1/inference_time_ms, plus a printed mean/median inference-time summary line
-- `verification_output/tracking_metrics_{model_type}.csv` — MOTA, IDF1, fragmentation (when `--ground-truth-tracks` is provided)
+- `verification_output/tracking_metrics_{model_type}_{tracker}.csv` — MOTA, IDF1, fragmentation for `--tracker trackpy|bytetrack` (default `trackpy`; when `--ground-truth-tracks` is provided)
 - `verification_output/tracking_visualization_{model_type}.mp4` — detection boxes and trajectory traces overlaid on every frame (when `--save-video` is passed)
 
-**Note:** The tracking metrics use a standalone `trackpy` linking pass configured via `tracking:` in `config.yaml`. This is NOT the production `particle-tracking/track.py` linker. Run a separate comparison against production tracker output before using MOTA/IDF1 for model selection decisions.
+**Note:** Tracking metrics link detections with the same `trackers_common` implementation
+`particle-tracking/track.py`'s production tracker uses — `--tracker trackpy` (default) shares its
+trackpy-linking implementation and per-model tuning; `--tracker bytetrack` shares its ByteTrack
+implementation, though its tuning is currently a single unmeasured default rather than a measured
+per-model split (see `trackers-common/README.md`). Both still honor `config.yaml`'s `tracking:`
+overrides.
 
 **Note:** MOTA/IDF1 are skipped (with a printed warning, not a crash) above a safe detection density or distinct-track-id count — building motmetrics' accumulator at this repo's default trajectory density (~1446 particles/frame) can grow memory into the double-digit-GB range even when the linking step itself succeeds. This is independent of `--save-video`'s own trajectory overlay, which uses a separate, always-attempted linking call and is unaffected by this guard (see `_run_tracking_metrics` in `benchmark.py`, and the multiprocessing/CUDA notes in `AGENTS.md`).
 
@@ -289,7 +294,7 @@ verification_output/
 ├── ground_truth.json           # pixel positions per frame (from render.py)
 ├── ground_truth_tracks.csv     # stable per-particle tracks (from render.py)
 ├── accuracy_metrics_{model_type}.csv   # per-frame precision/recall/F1/inference_time_ms (from benchmark.py)
-├── tracking_metrics_{model_type}.csv   # MOTA/IDF1/fragmentation (from benchmark.py)
+├── tracking_metrics_{model_type}_{tracker}.csv   # MOTA/IDF1/fragmentation, tracker=trackpy|bytetrack (from benchmark.py)
 ├── tracking_visualization_{model_type}.mp4  # detection boxes + trajectory traces (from benchmark.py --save-video)
 ├── benchmark_comparison.png    # per-frame metrics across model types (from plot_benchmark.py)
 ├── benchmark_summary.png       # run-level bar chart across model types (from plot_benchmark.py)

--- a/verification/README.md
+++ b/verification/README.md
@@ -3,11 +3,11 @@
 End-to-end pipeline for validating the simulation → detection → tracking chain with realistic synthetic rendering.
 
 1. **`render.py`** — converts a LAMMPS trajectory into synthetic microscopy TIFFs with known particle positions; writes `ground_truth.json` (per-frame positions) and `ground_truth_tracks.csv` (per-particle track ground truth for MOTA/IDF1).
-2. **`benchmark.py`** — runs RF-DETR, LodeSTAR, YOLOv12, or trackpy (`--model-type`) on synthetic frames and measures detection precision/recall/F1; optionally runs trackpy linking and computes MOTA/IDF1/fragmentation via motmetrics.
+2. **`benchmark.py`** — runs RF-DETR, LodeSTAR, YOLOv12, or trackpy (`--model-type`) on synthetic frames and measures detection precision/recall/F1; optionally runs trackpy or ByteTrack linking (`--tracker`) and computes MOTA/IDF1/fragmentation via motmetrics.
 3. **`compare.py`** — compares physics observables (hexatic order, MSD, velocity distributions) between the LAMMPS simulation and real particle tracks.
 4. **`calibrate_psf.py`** — fits PSF, background, intensity, and noise parameters from real `.tif` microscopy frames; prints calibrated values ready to paste into `config.yaml`.
 5. **`compare_renders.py`** — generates side-by-side visual and SNR/PSD comparison of all rendering strategies against a real reference frame.
-6. **`plot_benchmark.py`** — plots per-frame precision/recall/F1/mean position error/inference time across `benchmark.py`'s per-model-type outputs, plus a run-level summary bar chart (F1/MOTA/IDF1/fragmentations/ID switches/inference time), for comparing detector performance side by side.
+6. **`plot_benchmark.py`** — plots per-frame precision/recall/F1/mean position error/inference time across `benchmark.py`'s per-model-type outputs, plus a grouped MOTA/IDF1/fragmentations bar panel by (model, tracker) and a run-level summary bar chart (F1/MOTA/IDF1/fragmentations/ID switches/inference time), for comparing detector and tracker performance side by side.
 7. **`dataset_profile_builder.py`** — builds a dataset scale profile YAML (`size_px`/`spacing_px`) from a LAMMPS trajectory and a known `size_px`, computing `spacing_px` as the median per-particle nearest-neighbor distance. See `dataset-profiles/README.md` for the profile format and how `box_size`/`nms_distance`/`tile_size`/`search_range`/`diameter` derive from it.
 
 ## Setup
@@ -224,6 +224,7 @@ Options:
 | `--ground-truth-tracks` | *(optional)* | `ground_truth_tracks.csv` from render.py — enables tracking metrics |
 | `--config` | `config.yaml` | Config file |
 | `--model-type` | `rf-detr` | `rf-detr`, `lodestar`, `yolo`, or `trackpy` — overridden by `benchmark.model_type` in config when the flag is omitted |
+| `--tracker` | `trackpy` | `trackpy` or `bytetrack` — which `trackers_common` linker computes tracking metrics; no `config.yaml` equivalent to `benchmark.model_type` yet |
 | `--device` | `0` | CUDA device index or `cpu` |
 | `--save-video` | off | Write `tracking_visualization_{model_type}.mp4` with detection boxes and trajectory traces overlaid. Uses `tracking.search_range`/`memory` from `--config` to link detections, independent of `--ground-truth-tracks` (only needed for MOTA/IDF1) |
 | `--video-fps` | `10.0` | Frame rate for `--save-video` output |
@@ -238,6 +239,7 @@ Key settings in `config.yaml` under `tracking:`:
 | `memory` | Frames a particle can be absent before track ends |
 | `matching_threshold_radii` | motmetrics GT↔pred match threshold (× `psf_sigma_px`) |
 | `adaptive_stop` / `adaptive_step` | Opt-in trackpy per-subnet shrinking (off by default: `null`) — see `config.yaml`'s own comment before enabling against a dense dataset |
+| `lost_track_buffer` / `minimum_consecutive_frames` / `track_activation_threshold` | ByteTrack (`--tracker bytetrack`) tuning — like `search_range`/`memory`/`stub_filter`, left unset by default to resolve from the per-model canonical default in `trackers_common/tracker_defaults.yaml` |
 
 ## Step 3 — Compare physics observables
 
@@ -296,8 +298,8 @@ verification_output/
 ├── accuracy_metrics_{model_type}.csv   # per-frame precision/recall/F1/inference_time_ms (from benchmark.py)
 ├── tracking_metrics_{model_type}_{tracker}.csv   # MOTA/IDF1/fragmentation, tracker=trackpy|bytetrack (from benchmark.py)
 ├── tracking_visualization_{model_type}.mp4  # detection boxes + trajectory traces (from benchmark.py --save-video)
-├── benchmark_comparison.png    # per-frame metrics across model types (from plot_benchmark.py)
-├── benchmark_summary.png       # run-level bar chart across model types (from plot_benchmark.py)
+├── benchmark_comparison.png    # per-frame metrics across model types, plus a MOTA/IDF1/fragmentations bar panel by (model, tracker) (from plot_benchmark.py)
+├── benchmark_summary.png       # run-level bar chart across model types, using each model's trackpy tracking result (from plot_benchmark.py)
 ├── renders_comparison.png      # side-by-side strategy comparison (from compare_renders.py)
 ├── snr_psd_scores.csv          # per-strategy SNR and PSD similarity (from compare_renders.py)
 ├── hexatic_order.png           # structural order comparison (from compare.py)

--- a/verification/benchmark.py
+++ b/verification/benchmark.py
@@ -295,9 +295,11 @@ def resolve_tile_size(explicit_value, profile, frame_width, frame_height, hardco
 
 def detect_trackpy(frame, diameter, minmass=None, separation=None):
     """Locate particles with trackpy's classical brightness-thresholding
-    algorithm and return an sv.Detections object shaped like the other two
-    detectors' output (xyxy boxes, confidence left unset — see plan KTDs on
-    why trackpy's `mass` isn't surfaced as a confidence score)."""
+    algorithm and return an sv.Detections object shaped like the other
+    detectors' output (xyxy boxes, confidence a constant 1.0 -- see plan KTDs
+    on why trackpy's `mass` isn't surfaced as a confidence score instead; the
+    constant is needed so ByteTrack, which requires confidence to be set, can
+    run against trackpy's detections)."""
     import trackpy as tp
     import supervision as sv
 
@@ -307,11 +309,15 @@ def detect_trackpy(frame, diameter, minmass=None, separation=None):
     if features.empty:
         return sv.Detections.empty()
 
+    from detectors_common.point_to_box import points_to_xyxy
+
     xs = features["x"].to_numpy()
     ys = features["y"].to_numpy()
-    half = diameter / 2.0
-    xyxy = np.stack([xs - half, ys - half, xs + half, ys + half], axis=1).astype(np.float32)
-    return sv.Detections(xyxy=xyxy, class_id=np.zeros(len(xyxy), dtype=int))
+    centers = np.stack([xs, ys], axis=1)
+    xyxy = points_to_xyxy(centers, diameter)
+    return sv.Detections(
+        xyxy=xyxy, class_id=np.zeros(len(xyxy), dtype=int), confidence=np.ones(len(xyxy))
+    )
 
 
 def _load_lodestar_defaults(cfg):

--- a/verification/benchmark.py
+++ b/verification/benchmark.py
@@ -1017,6 +1017,271 @@ def _run_tracking_metrics(
     return result
 
 
+def _run_bytetrack_with_timeout(
+    all_detections,
+    lost_track_buffer,
+    minimum_consecutive_frames,
+    track_activation_threshold,
+    timeout_s=90,
+):
+    """Run trackers_common.bytetrack.run_bytetrack under a simple wall-clock
+    timeout (signal.alarm — POSIX only), as cheap insurance rather than
+    shipping it fully unguarded.
+
+    Deliberately NOT the subprocess/rlimit/retry machinery
+    _link_df_with_fallback uses for trackpy: sv.ByteTrack's per-frame IoU
+    association plus Kalman filter has no known combinatorial subnet-blowup
+    mode the way trackpy's recursive solver does (see this unit's plan KTD),
+    so this is only a bound against an *unverified* runtime/memory profile at
+    high particle density, not a guard against a confirmed pathology. A
+    signal-based timeout is sufficient for that and far simpler than spawning
+    a subprocess for every benchmark run.
+
+    Returns:
+        list[sv.Detections] on success, or None if it didn't finish within
+        timeout_s (a platform with no SIGALRM runs unbounded instead of
+        silently skipping the timeout).
+    """
+    import signal
+
+    from trackers_common.bytetrack import run_bytetrack
+
+    if not hasattr(signal, "SIGALRM"):
+        return run_bytetrack(
+            all_detections,
+            lost_track_buffer,
+            minimum_consecutive_frames,
+            track_activation_threshold,
+        )
+
+    def _handler(signum, frame):
+        raise TimeoutError(f"run_bytetrack exceeded {timeout_s}s")
+
+    previous_handler = signal.signal(signal.SIGALRM, _handler)
+    signal.alarm(timeout_s)
+    try:
+        return run_bytetrack(
+            all_detections,
+            lost_track_buffer,
+            minimum_consecutive_frames,
+            track_activation_threshold,
+        )
+    except TimeoutError:
+        return None
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous_handler)
+
+
+def _run_bytetrack_metrics(
+    all_boxes_by_frame,
+    gt_tracks_path,
+    cfg,
+    model_type,
+    derived_psf_sigma_px=None,
+    profile=None,  # pylint: disable=unused-argument
+):
+    """Track detections via trackers_common's shared ByteTrack wrapper
+    (trackers_common.bytetrack.run_bytetrack), then evaluate against ground
+    truth with motmetrics — the --tracker bytetrack counterpart to
+    _run_tracking_metrics's trackpy-linking path.
+
+    Unlike _run_tracking_metrics (a single batch call over all detections at
+    once), ByteTrack is a stateful, order-dependent, per-frame loop: this
+    builds one sv.Detections per frame from all_boxes_by_frame, in ascending
+    frame_idx order (not dict-insertion or glob order), so run_bytetrack's
+    frame-position-based lost_track_buffer timing lines up with ground
+    truth's actual frame spacing even across a gap — main()'s detection loop
+    already has an `if frame_idx not in gt_by_frame: continue` guard, so a
+    dataset with non-contiguous frame_idx values is a real possibility this
+    function must handle correctly, not assume away.
+
+    Args:
+        all_boxes_by_frame: dict frame_idx -> {"xyxy": (N,4) float array,
+            "confidence": (N,) float array} — one entry per detected frame,
+            populated unconditionally by main()'s detection loop (not only
+            for --save-video).
+        gt_tracks_path: path to ground_truth_tracks.csv
+        cfg: full config dict
+        model_type: active --model-type ("rf-detr", "lodestar", or "trackpy")
+            — resolves lost_track_buffer/minimum_consecutive_frames/
+            track_activation_threshold from trackers_common's canonical
+            per-model tuning (trackers_common.tracker_defaults.yaml).
+            "trackpy" has no track.py-side model_type of its own and falls
+            back to the rf-detr tuning (trackers_common.defaults.
+            FALLBACK_MODEL_TYPE) — a documented default, not a claim of
+            measured trackpy-detector parity.
+        derived_psf_sigma_px: if given, overrides cfg's synthetic.psf_sigma /
+            synthetic.psf.sigma_px for the match-threshold calculation — same
+            semantics as _run_tracking_metrics's own parameter.
+        profile: accepted for call-site symmetry with _run_tracking_metrics,
+            but unused here — R9: lost_track_buffer/minimum_consecutive_frames/
+            track_activation_threshold never derive from a dataset profile.
+
+    Returns:
+        dict of tracking metric values (same shape as _run_tracking_metrics's
+        result), or None if prerequisites are missing.
+    """
+    tracking_enabled = _cfg_get(cfg, "tracking", "enabled", default=True)
+    if not tracking_enabled:
+        return None
+
+    import importlib.util
+
+    # Existence check only -- _build_accumulator_with_timeout imports motmetrics
+    # itself, lazily, in its subprocess worker.
+    if importlib.util.find_spec("motmetrics") is None:
+        print(
+            "Warning: motmetrics not installed — skipping tracking metrics. Run: uv add motmetrics"
+        )
+        return None
+
+    try:
+        import supervision as sv
+    except ImportError:
+        print(
+            "Warning: supervision not installed — skipping tracking metrics. Run: uv add supervision"
+        )
+        return None
+
+    gt_path = Path(gt_tracks_path)
+    if not gt_path.exists():
+        print(f"Warning: {gt_path} not found — skipping tracking metrics (run render.py first).")
+        return None
+
+    import pandas as pd
+
+    gt_df = pd.read_csv(gt_path)
+    required = {"frame", "particle_id", "x", "y"}
+    if not required.issubset(gt_df.columns):
+        print(
+            f"Warning: {gt_path} missing columns {required - set(gt_df.columns)} — skipping tracking metrics."
+        )
+        return None
+
+    if not all_boxes_by_frame:
+        print("Warning: no detections accumulated — skipping tracking metrics.")
+        return None
+
+    # verification/config.yaml's own tracking: block can still override any of
+    # these per-model canonical values — same override precedence
+    # _run_tracking_metrics's search_range/memory/stub_filter already has.
+    tracking_defaults = load_tracking_config(model_type, cfg, DEFAULT_KEY_PATH_MAP)
+    lost_track_buffer = tracking_defaults.get("lost_track_buffer", 60)
+    minimum_consecutive_frames = tracking_defaults.get("minimum_consecutive_frames", 1)
+    track_activation_threshold = tracking_defaults.get("track_activation_threshold", 0.1)
+
+    threshold_radii = _cfg_get(cfg, "tracking", "matching_threshold_radii", default=0.5)
+    if derived_psf_sigma_px is not None:
+        psf_sigma_px = derived_psf_sigma_px
+    else:
+        psf_sigma_px = _resolve_psf_sigma_px(cfg)
+    match_threshold = threshold_radii * psf_sigma_px
+
+    # run_bytetrack's lost_track_buffer/minimum_consecutive_frames timing
+    # counts LIST POSITIONS, not real frame_idx values -- so the list handed
+    # to it must span every integer frame_idx from min to max inclusive
+    # (ascending, NOT dict-insertion or glob order), with an empty
+    # placeholder standing in for any frame_idx absent from
+    # all_boxes_by_frame. Just sorting the *present* keys would silently
+    # collapse a gap (e.g. frames 0, 1, 3 with 2 missing) into list-adjacency
+    # between frames 1 and 3 -- exactly the frame-position-vs-frame-index
+    # mismatch this function must not assume away, since main()'s detection
+    # loop already has an `if frame_idx not in gt_by_frame: continue` guard
+    # that can produce exactly this shape.
+    present_frame_indices = sorted(all_boxes_by_frame.keys())
+    full_frame_range = list(range(present_frame_indices[0], present_frame_indices[-1] + 1))
+    detections_list = []
+    for frame_idx in full_frame_range:
+        frame_boxes = all_boxes_by_frame.get(frame_idx)
+        xyxy = frame_boxes["xyxy"] if frame_boxes is not None else np.zeros((0, 4))
+        confidence = frame_boxes["confidence"] if frame_boxes is not None else np.zeros(0)
+        if len(xyxy) == 0:
+            detections_list.append(sv.Detections.empty())
+        else:
+            detections_list.append(
+                sv.Detections(
+                    xyxy=xyxy.astype(np.float64),
+                    confidence=confidence.astype(np.float64),
+                    class_id=np.zeros(len(xyxy), dtype=int),
+                )
+            )
+
+    tracked = _run_bytetrack_with_timeout(
+        detections_list,
+        lost_track_buffer,
+        minimum_consecutive_frames,
+        track_activation_threshold,
+    )
+    if tracked is None:
+        print(
+            "Warning: ByteTrack tracking did not finish within the timeout window -- "
+            "skipping tracking metrics."
+        )
+        return None
+
+    rows = []
+    for frame_idx, dets in zip(full_frame_range, tracked):
+        if dets.tracker_id is None or len(dets) == 0:
+            continue
+        centers = (dets.xyxy[:, :2] + dets.xyxy[:, 2:]) / 2
+        for (cx, cy), track_id in zip(centers, dets.tracker_id):
+            rows.append(
+                {"frame": frame_idx, "track_id": int(track_id), "x": float(cx), "y": float(cy)}
+            )
+
+    if not rows:
+        print("Warning: ByteTrack produced no confirmed tracks — skipping tracking metrics.")
+        return None
+
+    linked = pd.DataFrame(rows)
+
+    # Build the accumulator in a subprocess with a hard RLIMIT_AS memory
+    # ceiling and wall-clock timeout, same as _run_tracking_metrics's trackpy
+    # path -- see _build_accumulator_with_timeout's own docstring. This
+    # replaces an earlier in-process avg_det_per_frame/n_distinct_tracks
+    # pre-check (same rationale as the trackpy path: a pre-check meant dense
+    # results never got a chance to actually produce MOTA/IDF1 even when the
+    # real cost would have fit safely). The raw-density pre-check before
+    # _run_bytetrack_with_timeout above is unrelated and still applies -- it
+    # protects the tracking pass itself, not this accumulator-building step.
+    acc = _build_accumulator_with_timeout(gt_df, linked, psf_sigma_px, threshold_radii)
+    if acc is None:
+        print(
+            "Warning: building the MOTA/IDF1 accumulator did not finish within its "
+            "memory/time budget -- skipping tracking metrics."
+        )
+        return None
+
+    summary_dict = _compute_motmetrics_with_timeout(
+        acc,
+        metrics=[
+            "mota",
+            "idf1",
+            "num_fragmentations",
+            "num_switches",
+            "num_misses",
+            "num_false_positives",
+        ],
+    )
+    if summary_dict is None:
+        print("Warning: MOTA/IDF1 computation did not finish in time -- skipping tracking metrics.")
+        return None
+
+    result = {
+        "mota": float(summary_dict["mota"]),
+        "idf1": float(summary_dict["idf1"]),
+        "num_fragmentations": int(summary_dict["num_fragmentations"]),
+        "num_switches": int(summary_dict["num_switches"]),
+        "num_misses": int(summary_dict["num_misses"]),
+        "num_false_positives": int(summary_dict["num_false_positives"]),
+        "matching_threshold_radii": threshold_radii,
+        "psf_sigma_px": psf_sigma_px,
+        "match_threshold_px": match_threshold,
+    }
+    return result
+
+
 def _link_detections_for_video(all_boxes_by_frame, cfg, search_range, memory):
     """Link detections across frames via trackpy, for --save-video only.
 
@@ -1096,14 +1361,22 @@ def _write_tracking_video(
     import cv2
     import supervision as sv
 
-    if not any(len(boxes) > 0 for boxes in all_boxes_by_frame.values()):
+    if not any(len(frame_data["xyxy"]) > 0 for frame_data in all_boxes_by_frame.values()):
         print("Warning: no detections to draw -- skipping --save-video.")
         return
 
+    # _link_detections_for_video (and _link_df_with_fallback beneath it) only
+    # need each frame's xyxy boxes, not confidence -- extract a plain
+    # frame_idx -> xyxy view rather than changing that function's own
+    # dict-of-plain-arrays contract.
+    #
     # linked is {} whenever linking wasn't attempted (no detections) or failed
     # (SubnetOversizeException) -- _write_tracking_video still draws
     # box-only frames (no trace/track_id) from all_boxes_by_frame in that case.
-    linked = _link_detections_for_video(all_boxes_by_frame, cfg, search_range, memory)
+    xyxy_by_frame = {
+        frame_idx: frame_data["xyxy"] for frame_idx, frame_data in all_boxes_by_frame.items()
+    }
+    linked = _link_detections_for_video(xyxy_by_frame, cfg, search_range, memory)
 
     box_annotator = sv.BoxAnnotator()
     trace_annotator = sv.TraceAnnotator(trace_length=trace_length)
@@ -1118,7 +1391,7 @@ def _write_tracking_video(
             h, w = frame_rgb.shape[:2]
             writer = cv2.VideoWriter(str(video_path), fourcc, fps, (w, h))
 
-        boxes_this_frame = all_boxes_by_frame.get(frame_idx, np.zeros((0, 4)))
+        boxes_this_frame = all_boxes_by_frame.get(frame_idx, {"xyxy": np.zeros((0, 4))})["xyxy"]
         if frame_idx in linked:
             boxes, track_ids = linked[frame_idx]
             detections = sv.Detections(
@@ -1179,6 +1452,14 @@ def main():
         default=None,
         help=f"Detector to benchmark (default: {_DEFAULT_MODEL_TYPE}, or "
         "benchmark.model_type from --config)",
+    )
+    parser.add_argument(
+        "--tracker",
+        choices=["trackpy", "bytetrack"],
+        default="trackpy",
+        help="Tracking/linking algorithm used for --ground-truth-tracks metrics (default: "
+        "trackpy). Orthogonal to --model-type (the detector) -- any model_type works with "
+        "either tracker. Output filename: tracking_metrics_{model_type}_{tracker}.csv.",
     )
     parser.add_argument("--device", default=None, help="Inference device (e.g. 0 or cpu)")
     parser.add_argument(
@@ -1407,9 +1688,11 @@ def main():
     all_dists = []
     all_inference_times_ms = []
     all_detections_by_frame = {}  # frame_idx → (N, 2) array of (x, y) centroids
-    all_boxes_by_frame = (
-        {}
-    )  # frame_idx → (N, 4) array of xyxy boxes, only populated for --save-video
+    # frame_idx → {"xyxy": (N, 4) array, "confidence": (N,) array} -- populated
+    # unconditionally (not only for --save-video): --tracker bytetrack's
+    # _run_bytetrack_metrics also needs box+confidence data per frame, in
+    # addition to --save-video's own existing use.
+    all_boxes_by_frame = {}
 
     for png_path in tiff_files:
         frame_idx = int(png_path.stem.replace("frame_", ""))
@@ -1465,10 +1748,22 @@ def main():
         all_fn += fn
         all_dists.extend(dists)
         all_detections_by_frame[frame_idx] = pred_centers
-        if args.save_video:
-            all_boxes_by_frame[frame_idx] = (
-                dets.xyxy.astype(np.float64) if len(dets) > 0 else np.zeros((0, 4))
+        # Additive only -- all_detections_by_frame above is completely
+        # untouched by this. confidence falls back to all-ones when a
+        # detector doesn't set it (matches detect_trackpy's own default and
+        # keeps --tracker bytetrack runnable against every detector, since
+        # sv.ByteTrack requires confidence to be non-None).
+        if len(dets) > 0:
+            boxes_xyxy = dets.xyxy.astype(np.float64)
+            boxes_confidence = (
+                dets.confidence.astype(np.float64)
+                if dets.confidence is not None
+                else np.ones(len(dets), dtype=np.float64)
             )
+        else:
+            boxes_xyxy = np.zeros((0, 4))
+            boxes_confidence = np.zeros(0, dtype=np.float64)
+        all_boxes_by_frame[frame_idx] = {"xyxy": boxes_xyxy, "confidence": boxes_confidence}
 
         prec = tp / (tp + fp) if (tp + fp) > 0 else 0.0
         rec = tp / (tp + fn) if (tp + fn) > 0 else 0.0
@@ -1559,16 +1854,33 @@ def main():
                 f"(derived from --lammps-in {args.lammps_in})"
             )
 
-        tracking_metrics = _run_tracking_metrics(
-            all_detections_by_frame,
-            args.ground_truth_tracks,
-            full_cfg,
-            model_type,
-            derived_psf_sigma_px=derived_psf_sigma_px,
-            profile=tracking_profile,
-        )
+        # --tracker trackpy -> the existing batch/offline linker path
+        # (unchanged behavior); --tracker bytetrack -> the per-frame online
+        # tracker path (U5). Orthogonal to --model-type (the detector).
+        if args.tracker == "bytetrack":
+            tracking_metrics = _run_bytetrack_metrics(
+                all_boxes_by_frame,
+                args.ground_truth_tracks,
+                full_cfg,
+                model_type,
+                derived_psf_sigma_px=derived_psf_sigma_px,
+                profile=tracking_profile,
+            )
+        else:
+            tracking_metrics = _run_tracking_metrics(
+                all_detections_by_frame,
+                args.ground_truth_tracks,
+                full_cfg,
+                model_type,
+                derived_psf_sigma_px=derived_psf_sigma_px,
+                profile=tracking_profile,
+            )
         if tracking_metrics:
-            tracking_csv_path = output_dir / f"tracking_metrics_{model_type}.csv"
+            # Uniform naming for both trackers (not just bytetrack) -- see
+            # this unit's plan KTD: a one-time rename now is simpler than
+            # carrying two permanently different naming conventions for the
+            # same kind of artifact.
+            tracking_csv_path = output_dir / f"tracking_metrics_{model_type}_{args.tracker}.csv"
             with open(tracking_csv_path, "w", newline="") as f:
                 writer = csv.DictWriter(f, fieldnames=list(tracking_metrics.keys()))
                 writer.writeheader()

--- a/verification/benchmark.py
+++ b/verification/benchmark.py
@@ -384,6 +384,28 @@ def _resolve_psf_sigma_px(cfg):
     return psf_sigma_px
 
 
+def _resolve_match_distance(cfg, full_cfg):
+    """Accuracy metrics' (precision/recall/F1) match_distance, derived from
+    the SAME tracking.matching_threshold_radii x psf_sigma_px formula the
+    tracking metrics (MOTA/IDF1) already use -- not a disconnected hardcoded
+    literal. Without this, a detection can count as a correct match for
+    accuracy (a loose radius) while failing the tracking metrics' stricter
+    identity match (a tighter, unrelated radius) purely from normal
+    localization jitter, not a real accuracy-vs-tracking disagreement --
+    confirmed directly: rf-detr's own mean position error (~2.2px) sits close
+    to the derived ~2.5px default, so a meaningful fraction of genuinely
+    correct detections were failing the old disconnected 10px-vs-2.5px split.
+
+    `benchmark.match_distance` in config.yaml, when explicitly set, still
+    wins over this derived value, matching this file's established
+    explicit-value-always-wins override convention.
+    """
+    threshold_radii = _cfg_get(full_cfg, "tracking", "matching_threshold_radii", default=0.5)
+    return _cfg_get(
+        cfg, "match_distance", default=threshold_radii * _resolve_psf_sigma_px(full_cfg)
+    )
+
+
 # ---------------------------------------------------------------------------
 # Detection matching
 # ---------------------------------------------------------------------------
@@ -1543,7 +1565,7 @@ def main():
     # Sourced from the same _MODEL_VENV_DIRS/_DEFAULT_MODEL_TYPE as the
     # module-level _resolve_model_type pre-parse, so the two can't drift.
     model_type = args.model_type or _cfg_get(cfg, "model_type", default=_DEFAULT_MODEL_TYPE)
-    match_distance = _cfg_get(cfg, "match_distance", default=10)
+    match_distance = _resolve_match_distance(cfg, full_cfg)
 
     # Dataset scale profile (size_px/spacing_px): when referenced, box_size/
     # nms_distance/tile_size/diameter/search_range/memory each derive from it

--- a/verification/benchmark.py
+++ b/verification/benchmark.py
@@ -1221,25 +1221,19 @@ def _run_bytetrack_metrics(
     # that can produce exactly this shape.
     present_frame_indices = sorted(all_boxes_by_frame.keys())
 
-    # Pre-check raw detection density BEFORE running ByteTrack (which can take
-    # up to _run_bytetrack_with_timeout's full timeout window) rather than
-    # only after -- at this repo's default dataset density (~1446/frame,
-    # already ~3.6x over this threshold), every default --tracker bytetrack
-    # run would otherwise pay for a full, unverified-cost tracking pass only
-    # to discard the result via the identical check below. Raw density alone
-    # (not n_distinct_tracks, which only exists post-tracking) is available
-    # this early -- the post-tracking check further down still catches
-    # fragmentation the raw count can't predict.
-    raw_avg_det_per_frame = sum(
-        len(all_boxes_by_frame[fi]["xyxy"]) for fi in present_frame_indices
-    ) / max(1, len(present_frame_indices))
-    if raw_avg_det_per_frame > 400:
-        print(
-            f"Warning: raw detection density ({raw_avg_det_per_frame:.0f}/frame) is too high "
-            "to safely run ByteTrack tracking in-process. Skipping tracking metrics."
-        )
-        return None
-
+    # No raw-density pre-check here (unlike the accumulator-building step
+    # below, which is subprocess/RLIMIT-isolated the same way trackpy's is).
+    # An earlier version of this function had one at 400 det/frame, copied
+    # from trackpy's own accumulator-protection threshold -- but that number
+    # was never validated against ByteTrack's actual cost, and measuring it
+    # directly against this repo's real dataset (~1167-1446 det/frame,
+    # temporally coherent) showed run_bytetrack completing in ~18s, nowhere
+    # near _run_bytetrack_with_timeout's 90s budget. A synthetic worst-case
+    # test with fully random (temporally-incoherent) positions did take ~99s
+    # at the same density, but that's an adversarial case IoU-based
+    # association is inherently bad at, not representative of real slowly-
+    # moving particles -- and the timeout+MemoryError catch already degrades
+    # gracefully if a genuinely pathological input ever hits it.
     full_frame_range = list(range(present_frame_indices[0], present_frame_indices[-1] + 1))
     detections_list = []
     for frame_idx in full_frame_range:

--- a/verification/benchmark.py
+++ b/verification/benchmark.py
@@ -1155,14 +1155,13 @@ def _run_bytetrack_metrics(
             for --save-video).
         gt_tracks_path: path to ground_truth_tracks.csv
         cfg: full config dict
-        model_type: active --model-type ("rf-detr", "lodestar", or "trackpy")
-            — resolves lost_track_buffer/minimum_consecutive_frames/
+        model_type: active --model-type ("rf-detr", "lodestar", "yolo", or
+            "trackpy") — resolves lost_track_buffer/minimum_consecutive_frames/
             track_activation_threshold from trackers_common's canonical
-            per-model tuning (trackers_common.tracker_defaults.yaml).
-            "trackpy" has no track.py-side model_type of its own and falls
-            back to the rf-detr tuning (trackers_common.defaults.
-            FALLBACK_MODEL_TYPE) — a documented default, not a claim of
-            measured trackpy-detector parity.
+            per-model tuning (trackers_common.tracker_defaults.yaml), each
+            independently swept against real data. rf-detr/yolo converge on
+            minimum_consecutive_frames=1; lodestar/trackpy (noisier per-frame
+            confidence) converge on minimum_consecutive_frames=3 instead.
         derived_psf_sigma_px: if given, overrides cfg's synthetic.psf_sigma /
             synthetic.psf.sigma_px for the match-threshold calculation — same
             semantics as _run_tracking_metrics's own parameter.

--- a/verification/benchmark.py
+++ b/verification/benchmark.py
@@ -9,26 +9,46 @@ known particle positions, and reports per-frame precision/recall/F1 and mean
 position error.
 
 Optionally computes MOTA/IDF1/fragmentation via py-motmetrics when
---ground-truth-tracks is supplied (CSV from render.py U1).
+--ground-truth-tracks is supplied (CSV from render.py U1), for either tracker
+selected via --tracker {trackpy,bytetrack} (default trackpy) -- orthogonal to
+--model-type, the detector. This supersedes an earlier plan's KTD that left
+"bytetrack linker parity" out of scope; that deferral was correct when the
+goal was closing a dependency gap for trackpy's own metrics, but ByteTrack
+evaluation is this module's own goal now
+(docs/plans/2026-08-18-001-feat-bytetrack-tracking-support-plan.md).
 
-Tracking metrics link detections with trackers_common.linking.link_and_filter_tracks
+--tracker trackpy links detections with trackers_common.linking.link_and_filter_tracks
 -- the same trackpy-linking implementation particle-tracking/track.py's production
 tracker uses -- resolving search_range/memory/stub_filter from trackers_common's
 canonical per-model tuning (the same values particle-tracking/tracker_configs.py
 generates for real per-model production comparison runs), not a generic value
-shared across all detectors. verification/config.yaml's tracking: section can still
-override these per-model defaults when set explicitly. --model-type trackpy (a
-classical detector with no particle-tracking/track.py model_type of its own) falls
-back to the rf-detr tuning as a documented default, not a claim of measured parity.
-bytetrack linker parity is out of scope -- only the trackpy-linking path, which is
-production's configured default tracker, is unified.
+shared across all detectors. --tracker bytetrack tracks detections online,
+per-frame, via trackers_common.bytetrack.run_bytetrack (the same implementation
+particle-tracking/track.py's own --tracker bytetrack uses), resolving
+lost_track_buffer/minimum_consecutive_frames/track_activation_threshold from
+trackers_common's canonical defaults through the same mechanism. Both trackers'
+canonical values still honor verification/config.yaml's tracking: section as an
+override when set explicitly. --model-type trackpy (a classical detector with no
+particle-tracking/track.py model_type of its own) falls back to the rf-detr
+tuning for both trackers, as a documented default, not a claim of measured
+parity.
+
+Two fairness caveats matter for reading plot_benchmark.py's tracking-metrics bar
+panel: (1) trackpy's tuning is a genuinely measured per-model split (see
+trackers_common/tracker_defaults.yaml's comments); ByteTrack's tuning is a
+single unmeasured value carried forward identically across every model type
+(same file) -- a trackpy-vs-bytetrack comparison today is not yet
+apples-to-apples on tuning quality, only on what each tracker does with its
+current defaults. (2) track_activation_threshold has no effect on the
+`trackpy` detector specifically, since detect_trackpy's synthesized
+confidence (always 1.0) exceeds any plausible threshold value.
 
 Usage:
     uv run python benchmark.py \\
         --frames verification_output/synthetic_frames/ \\
         --ground-truth verification_output/ground_truth.json \\
         --ground-truth-tracks verification_output/ground_truth_tracks.csv \\
-        [--model-type rf-detr|lodestar|yolo|trackpy]
+        [--model-type rf-detr|lodestar|yolo|trackpy] [--tracker trackpy|bytetrack]
 """
 
 import os

--- a/verification/benchmark.py
+++ b/verification/benchmark.py
@@ -303,13 +303,17 @@ def resolve_tile_size(explicit_value, profile, frame_width, frame_height, hardco
 
 
 # ---------------------------------------------------------------------------
-# trackpy detection — NOT re-exported from detectors_common. Unlike RF-DETR
-# and LodeSTAR, trackpy has no CUDA/compiled-extension dependency and is
-# already a native dependency of verification/pyproject.toml (used today for
-# the tracking-metrics pass below), so it needs no cross-venv site-packages
-# injection and no re-exec (see _MODEL_VENV_DIRS["trackpy"] = None above).
-# It has exactly one consumer (this file), so routing it through the shared
-# package would add indirection with no sharing benefit.
+# trackpy detection (tp.locate itself) — NOT re-exported from
+# detectors_common. Unlike RF-DETR and LodeSTAR, trackpy has no
+# CUDA/compiled-extension dependency and is already a native dependency of
+# verification/pyproject.toml (used today for the tracking-metrics pass
+# below), so it needs no cross-venv site-packages injection and no re-exec
+# (see _MODEL_VENV_DIRS["trackpy"] = None above). tp.locate() itself has
+# exactly one consumer (this file), so routing it through the shared package
+# would add indirection with no sharing benefit -- but its point-to-box
+# synthesis step (points_to_xyxy, below) DOES have a second consumer
+# (detect_lodestar) and lives in detectors_common for that reason; see
+# detectors_common/point_to_box.py's own docstring.
 # ---------------------------------------------------------------------------
 
 
@@ -1086,7 +1090,13 @@ def _run_bytetrack_with_timeout(
             minimum_consecutive_frames,
             track_activation_threshold,
         )
-    except TimeoutError:
+    except (TimeoutError, MemoryError):
+        # MemoryError alongside TimeoutError: this call runs in-process with
+        # no subprocess/rlimit isolation (unlike trackpy's
+        # _link_df_with_fallback), so a real memory blowup at high density
+        # must degrade the same way a timeout does -- crashing the whole
+        # benchmark.py process on one detector's tracking metrics would be
+        # worse than skipping just that metric with a warning.
         return None
     finally:
         signal.alarm(0)
@@ -1210,6 +1220,26 @@ def _run_bytetrack_metrics(
     # loop already has an `if frame_idx not in gt_by_frame: continue` guard
     # that can produce exactly this shape.
     present_frame_indices = sorted(all_boxes_by_frame.keys())
+
+    # Pre-check raw detection density BEFORE running ByteTrack (which can take
+    # up to _run_bytetrack_with_timeout's full timeout window) rather than
+    # only after -- at this repo's default dataset density (~1446/frame,
+    # already ~3.6x over this threshold), every default --tracker bytetrack
+    # run would otherwise pay for a full, unverified-cost tracking pass only
+    # to discard the result via the identical check below. Raw density alone
+    # (not n_distinct_tracks, which only exists post-tracking) is available
+    # this early -- the post-tracking check further down still catches
+    # fragmentation the raw count can't predict.
+    raw_avg_det_per_frame = sum(
+        len(all_boxes_by_frame[fi]["xyxy"]) for fi in present_frame_indices
+    ) / max(1, len(present_frame_indices))
+    if raw_avg_det_per_frame > 400:
+        print(
+            f"Warning: raw detection density ({raw_avg_det_per_frame:.0f}/frame) is too high "
+            "to safely run ByteTrack tracking in-process. Skipping tracking metrics."
+        )
+        return None
+
     full_frame_range = list(range(present_frame_indices[0], present_frame_indices[-1] + 1))
     detections_list = []
     for frame_idx in full_frame_range:
@@ -1235,8 +1265,8 @@ def _run_bytetrack_metrics(
     )
     if tracked is None:
         print(
-            "Warning: ByteTrack tracking did not finish within the timeout window -- "
-            "skipping tracking metrics."
+            "Warning: ByteTrack tracking did not finish within the timeout window or ran "
+            "out of memory -- skipping tracking metrics."
         )
         return None
 

--- a/verification/config.yaml
+++ b/verification/config.yaml
@@ -505,14 +505,16 @@ benchmark:
 # --- benchmark.py: tracking metrics (requires ground_truth_tracks.csv from render.py) ---
 tracking:
   enabled: true
-  # search_range/memory/stub_filter are intentionally NOT set here -- leaving
-  # them unset lets benchmark.py resolve each --model-type's real
-  # production-tuned values from trackers_common's canonical tracker_defaults.yaml
-  # (the same values particle-tracking/tracker_configs.py generates for real
-  # per-model production runs), instead of one generic value across all
-  # detectors. Set search_range/memory/stub_filter here only to deliberately
-  # override the canonical per-model default for a specific investigation --
-  # any value set here always wins over the canonical default.
+  # search_range/memory/stub_filter (--tracker trackpy) and
+  # lost_track_buffer/minimum_consecutive_frames/track_activation_threshold
+  # (--tracker bytetrack) are intentionally NOT set here -- leaving them unset
+  # lets benchmark.py resolve each --model-type's real production-tuned
+  # values from trackers_common's canonical tracker_defaults.yaml (the same
+  # values particle-tracking/tracker_configs.py generates for real per-model
+  # production runs), instead of one generic value across all detectors. Set
+  # any of these here only to deliberately override the canonical per-model
+  # default for a specific investigation -- any value set here always wins
+  # over the canonical default.
   matching_threshold_radii: 0.5 # motmetrics GT↔pred match threshold (× psf_sigma_px)
   # trackpy.link_df's recursive subnet solver raises SubnetOversizeException
   # when too many candidate particles are mutually within search_range of

--- a/verification/config.yaml
+++ b/verification/config.yaml
@@ -376,7 +376,17 @@ synthetic:
 # --- benchmark.py: detection accuracy on synthetic frames ---
 benchmark:
   model_type: rf-detr       # rf-detr | lodestar | yolo | trackpy — overridden by --model-type
-  match_distance: 10        # pixels — max center-to-center dist to count a detection as TP; shared across model types
+  # match_distance intentionally NOT set here -- leaving it unset derives it from
+  # tracking.matching_threshold_radii x synthetic.psf_sigma (same formula the
+  # MOTA/IDF1 tracking metrics already use), so a detection means the same thing
+  # for accuracy and tracking purposes. Previously a disconnected hardcoded 10px
+  # here let a detection count as a correct match for precision/recall/F1 while
+  # still failing tracking's stricter identity match purely from normal
+  # localization jitter (rf-detr's own mean position error is ~2.2px, close to
+  # the derived ~2.5px threshold) -- not a real accuracy-vs-tracking
+  # disagreement. Set match_distance here only to override the derived value
+  # for a specific investigation -- any value set here always wins.
+  # match_distance: 10
 
   # --- model_type: rf-detr ---
   # checkpoints/checkpoint_best_ema.pth (May) is an undertrained/stale run —

--- a/verification/plot_benchmark.py
+++ b/verification/plot_benchmark.py
@@ -2,6 +2,18 @@
 """Plot per-frame precision/recall/F1/position-error across benchmark.py's
 per-model-type outputs, for comparing detector performance side by side.
 
+Writes two figures:
+- benchmark_comparison.png: the per-frame line panels above, plus a grouped
+  bar panel for aggregate tracking metrics (MOTA/IDF1/fragmentations) when
+  tracking_metrics_{model_type}_{tracker}.csv files are present -- one bar
+  group per model_type, one bar per tracker (trackpy/bytetrack) within that
+  group.
+- benchmark_summary.png: one bar per model per run-level scalar (F1, MOTA,
+  IDF1, fragmentations, ID switches, median inference time) -- MOTA/IDF1/
+  fragmentations/ID switches use each model's trackpy result specifically
+  (this figure predates --tracker bytetrack and stays one-bar-per-model; see
+  benchmark_comparison.png's bar panel for the tracker-inclusive view).
+
 CLI: uv run python plot_benchmark.py [--output-dir verification_output/]
      [--models rf-detr lodestar]
 """
@@ -14,6 +26,7 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+from matplotlib.patches import Patch
 
 # Fixed categorical order (never cycled/reassigned) — see verification/README.md
 # and the repo's dataviz conventions. New model types append the next slot.
@@ -34,6 +47,25 @@ _METRICS = [
     ("f1", "F1"),
     ("mean_pos_error_px", "Mean position error (px)"),
 ]
+
+_TRACKING_METRICS = [
+    ("mota", "MOTA"),
+    ("idf1", "IDF1"),
+    ("num_fragmentations", "Fragmentations"),
+]
+
+# Fixed tracker display order (matches benchmark.py's --tracker choices) so bar
+# groups and legends are always ordered the same way regardless of glob order.
+# Unknown/future tracker names sort alphabetically after these.
+_TRACKER_ORDER = ["trackpy", "bytetrack"]
+_HATCHES = ["", "///", "xxx", "..."]
+
+
+def _tracker_sort_key(tracker):
+    try:
+        return (0, _TRACKER_ORDER.index(tracker))
+    except ValueError:
+        return (1, tracker)
 
 
 def _read_accuracy_csv(path):
@@ -107,6 +139,121 @@ def _color_for(model_type, seen_order):
     return "#898781"
 
 
+def _style_axes(ax):
+    """Apply this file's shared minimal/muted axis styling."""
+    ax.grid(True, axis="y", color=_GRID_COLOR, linewidth=0.8)
+    ax.set_axisbelow(True)
+    for spine in ("top", "right"):
+        ax.spines[spine].set_visible(False)
+    for spine in ("left", "bottom"):
+        ax.spines[spine].set_color(_AXIS_COLOR)
+    ax.tick_params(colors=_MUTED, labelsize=8)
+
+
+def _plot_tracking_bars(ax, model_order, per_tracking, metric_key, label):
+    """Grouped bar chart for one aggregate tracking metric: one bar group per
+    model_type (in model_order, filtered to those with >=1 tracker present),
+    one bar per tracker within the group. Bar color reuses _color_for's
+    fixed model-type color; trackers within a group are distinguished by
+    hatch pattern (and a slight alpha shade) rather than color, since color
+    is reserved for model identity per this file's convention."""
+    groups = [m for m in model_order if any(mt == m for (mt, _tr) in per_tracking)]
+    if not groups:
+        ax.text(
+            0.5,
+            0.5,
+            "no tracking metrics",
+            ha="center",
+            va="center",
+            color=_MUTED,
+            fontsize=9,
+            transform=ax.transAxes,
+        )
+        ax.set_xticks([])
+        ax.set_yticks([])
+        for spine in ax.spines.values():
+            spine.set_visible(False)
+        ax.set_title(label, fontsize=10, color=_INK)
+        return
+
+    bar_width = 0.32
+    gap = 0.04
+    for gi, model_type in enumerate(groups):
+        trackers = sorted(
+            (tr for (mt, tr) in per_tracking if mt == model_type),
+            key=_tracker_sort_key,
+        )
+        color = _color_for(model_type, model_order)
+        n = len(trackers)
+        for idx, tracker in enumerate(trackers):
+            offset = (idx - (n - 1) / 2) * (bar_width + gap)
+            raw = per_tracking[(model_type, tracker)][metric_key]
+            value = int(raw) if metric_key == "num_fragmentations" else float(raw)
+            ax.bar(
+                gi + offset,
+                value,
+                width=bar_width,
+                color=color,
+                edgecolor=_INK,
+                linewidth=0.6,
+                hatch=_HATCHES[idx % len(_HATCHES)],
+                alpha=1.0 if idx == 0 else 0.7,
+            )
+
+    ax.set_xticks(range(len(groups)))
+    ax.set_xticklabels(groups, fontsize=8, color=_MUTED)
+    ax.set_title(label, fontsize=10, color=_INK)
+    _style_axes(ax)
+
+
+def _build_figure():
+    """2x2 grid of per-frame line panels (top), grouped bar panels for
+    aggregate tracking metrics below (bottom row). The bottom row's 3 panels
+    each span 2 of the mosaic's 6 columns, vs. the top row's 2 panels each
+    spanning 3 -- a stacked-below layout that keeps both mark types (lines
+    for per-frame series, bars for single aggregate values) in the same
+    figure without cramming bars into a line-panel slot."""
+    mosaic = [
+        ["precision", "precision", "precision", "recall", "recall", "recall"],
+        [
+            "f1",
+            "f1",
+            "f1",
+            "mean_pos_error_px",
+            "mean_pos_error_px",
+            "mean_pos_error_px",
+        ],
+        ["mota", "mota", "idf1", "idf1", "num_fragmentations", "num_fragmentations"],
+    ]
+    return plt.subplot_mosaic(mosaic, figsize=(12, 11.5))
+
+
+def _add_tracker_legend(fig, per_tracking):
+    """Add a small secondary legend mapping hatch pattern -> tracker name,
+    separate from the model-color legend (color already means model_type)."""
+    if not per_tracking:
+        return
+    trackers_seen = sorted({tr for (_mt, tr) in per_tracking}, key=_tracker_sort_key)
+    tracker_handles = [
+        Patch(
+            facecolor="white",
+            edgecolor=_INK,
+            hatch=_HATCHES[i % len(_HATCHES)],
+            label=tracker,
+        )
+        for i, tracker in enumerate(trackers_seen)
+    ]
+    fig.legend(
+        handles=tracker_handles,
+        loc="upper right",
+        ncol=len(tracker_handles),
+        frameon=False,
+        fontsize=8,
+        title="tracker",
+        title_fontsize=8,
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Plot per-frame benchmark metrics across model types"
@@ -134,6 +281,10 @@ def main():
         raise SystemExit(1)
 
     per_model = {}
+    # Keyed by (model_type, tracker) — a model can have 0, 1, or 2 tracker
+    # results present (trackpy, bytetrack, or both); see U5's
+    # tracking_metrics_{model_type}_{tracker}.csv naming scheme.
+    per_tracking = {}
     for model_type in model_types:
         csv_path = out / f"accuracy_metrics_{model_type}.csv"
         if not csv_path.exists():
@@ -141,16 +292,15 @@ def main():
             continue
         frames, series = _read_accuracy_csv(csv_path)
         aggregate = _aggregate_from_csv(csv_path)
-        tracking = None
-        tracking_path = out / f"tracking_metrics_{model_type}.csv"
-        if tracking_path.exists():
-            tracking = _read_tracking_csv(tracking_path)
         per_model[model_type] = {
             "frames": frames,
             "series": series,
             "aggregate": aggregate,
-            "tracking": tracking,
         }
+        prefix = f"tracking_metrics_{model_type}_"
+        for tracking_path in sorted(out.glob(f"{prefix}*.csv")):
+            tracker = tracking_path.stem[len(prefix) :]
+            per_tracking[(model_type, tracker)] = _read_tracking_csv(tracking_path)
 
     # --- Summary table (stdout) — the table-view twin of the plot below ---
     header = (
@@ -167,20 +317,30 @@ def main():
             f"{model_type:<10} {a['precision']:>10.4f} {a['recall']:>8.4f} "
             f"{a['f1']:>8.4f} {a['mean_pos_error_px']:>12.2f} {median_str:>16}"
         )
-    if any(data["tracking"] for data in per_model.values()):
+    if per_tracking:
         print()
-        print(f"{'model':<10} {'mota':>8} {'idf1':>8} {'fragmentations':>15} {'id_switches':>12}")
-        for model_type, data in per_model.items():
-            t = data["tracking"]
-            if t:
+        tracking_header = (
+            f"{'model':<10} {'tracker':<10} {'mota':>8} {'idf1':>8} {'fragmentations':>15} "
+            f"{'id_switches':>12}"
+        )
+        print(tracking_header)
+        print("-" * len(tracking_header))
+        for model_type in per_model:
+            trackers = sorted(
+                (tr for (mt, tr) in per_tracking if mt == model_type),
+                key=_tracker_sort_key,
+            )
+            for tracker in trackers:
+                t = per_tracking[(model_type, tracker)]
                 print(
-                    f"{model_type:<10} {float(t['mota']):>8.4f} {float(t['idf1']):>8.4f} "
-                    f"{int(t['num_fragmentations']):>15} {int(t['num_switches']):>12}"
+                    f"{model_type:<10} {tracker:<10} {float(t['mota']):>8.4f} "
+                    f"{float(t['idf1']):>8.4f} {int(t['num_fragmentations']):>15} "
+                    f"{int(t['num_switches']):>12}"
                 )
 
-    # --- Plot: one panel per metric, one line per model, fixed color order ---
-    fig, axes = plt.subplots(2, 2, figsize=(11, 8))
-    axes = axes.flatten()
+    # --- Plot: per-frame line panels plus grouped tracking-metric bar panels ---
+    fig, axd = _build_figure()
+    axes = [axd[key] for key, _ in _METRICS]
 
     for ax, (key, label) in zip(axes, _METRICS):
         for model_type, data in per_model.items():
@@ -202,8 +362,13 @@ def main():
             ax.spines[spine].set_color(_AXIS_COLOR)
         ax.tick_params(colors=_MUTED, labelsize=8)
 
+    for key, label in _TRACKING_METRICS:
+        _plot_tracking_bars(axd[key], list(per_model.keys()), per_tracking, key, label)
+
     handles, labels = axes[0].get_legend_handles_labels()
     fig.legend(handles, labels, loc="upper center", ncol=len(per_model), frameon=False)
+    _add_tracker_legend(fig, per_tracking)
+
     fig.tight_layout(rect=[0, 0, 1, 0.94])
 
     png_path = out / "benchmark_comparison.png"
@@ -216,39 +381,60 @@ def main():
     # sweeps only ever printed as text -- F1, MOTA, IDF1, fragmentations, ID
     # switches, and inference time all need to be visually comparable across
     # all four methods too, not just readable off a table.
-    summary_path = _plot_summary_bars(per_model, out)
+    summary_path = _plot_summary_bars(per_model, per_tracking, out)
     if summary_path:
         print(f"Summary plot -> {summary_path}")
 
 
-def _plot_summary_bars(per_model, out):
+def _plot_summary_bars(per_model, per_tracking, out):
     """One bar chart per run-level scalar metric (F1, MOTA, IDF1,
     fragmentations, ID switches, median inference time), one bar per model,
     same fixed color order as the per-frame line plots. Tracking-metric
     panels are skipped entirely if no model has tracking data (no
     --ground-truth-tracks run); the inference-time panel is skipped if no
     model's CSV has timing (older run, before benchmark.py recorded it).
+
+    Unlike _plot_tracking_bars (grouped by (model, tracker), showing every
+    tracker present), this figure is one-bar-per-model -- for a model with
+    multiple trackers' results present, it shows trackpy's specifically
+    (this figure predates --tracker bytetrack; trackpy is the default
+    tracker and the closest match to this figure's original one-tracker-
+    per-model assumption). A model with only a bytetrack result and no
+    trackpy result contributes no bar to this figure -- see
+    _plot_tracking_bars for the tracker-inclusive view.
     """
     models = list(per_model.keys())
-    has_tracking = any(data["tracking"] for data in per_model.values())
+
+    def _trackpy_result(model):
+        return per_tracking.get((model, "trackpy"))
+
+    has_tracking = any(_trackpy_result(m) for m in models)
     has_timing = any(
         data["aggregate"]["median_inference_ms"] is not None for data in per_model.values()
     )
 
-    panels = [("f1", "F1", lambda d: d["aggregate"]["f1"])]
+    panels = [("f1", "F1", lambda d, m: d["aggregate"]["f1"])]
     if has_tracking:
         panels += [
-            ("mota", "MOTA", lambda d: float(d["tracking"]["mota"]) if d["tracking"] else None),
-            ("idf1", "IDF1", lambda d: float(d["tracking"]["idf1"]) if d["tracking"] else None),
+            (
+                "mota",
+                "MOTA",
+                lambda d, m: float(t["mota"]) if (t := _trackpy_result(m)) else None,
+            ),
+            (
+                "idf1",
+                "IDF1",
+                lambda d, m: float(t["idf1"]) if (t := _trackpy_result(m)) else None,
+            ),
             (
                 "fragmentations",
                 "Fragmentations",
-                lambda d: int(d["tracking"]["num_fragmentations"]) if d["tracking"] else None,
+                lambda d, m: int(t["num_fragmentations"]) if (t := _trackpy_result(m)) else None,
             ),
             (
                 "id_switches",
                 "ID switches",
-                lambda d: int(d["tracking"]["num_switches"]) if d["tracking"] else None,
+                lambda d, m: int(t["num_switches"]) if (t := _trackpy_result(m)) else None,
             ),
         ]
     if has_timing:
@@ -256,7 +442,7 @@ def _plot_summary_bars(per_model, out):
             (
                 "inference_ms",
                 "Inference time (ms/frame, median)",
-                lambda d: d["aggregate"]["median_inference_ms"],
+                lambda d, m: d["aggregate"]["median_inference_ms"],
             )
         )
 
@@ -271,7 +457,7 @@ def _plot_summary_bars(per_model, out):
     axes = axes.flatten() if len(panels) > 1 else [axes]
 
     for ax, (_, label, getter) in zip(axes, panels):
-        values = [getter(per_model[m]) for m in models]
+        values = [getter(per_model[m], m) for m in models]
         bar_models = [m for m, v in zip(models, values) if v is not None]
         bar_values = [v for v in values if v is not None]
         bar_colors = [_color_for(m, models) for m in bar_models]

--- a/verification/plot_benchmark.py
+++ b/verification/plot_benchmark.py
@@ -68,6 +68,20 @@ def _tracker_sort_key(tracker):
         return (1, tracker)
 
 
+def _hatch_index_for(tracker):
+    """Canonical hatch/alpha index for a tracker name, fixed by _TRACKER_ORDER
+    position -- NOT by enumerate() position within whatever subset of
+    trackers happens to be present for one model or globally. A model with
+    only 'bytetrack' present must still use bytetrack's fixed index (1), the
+    same index _add_tracker_legend uses for it, or the bar's styling would
+    silently mismatch what the legend claims (found during review:
+    correctness)."""
+    try:
+        return _TRACKER_ORDER.index(tracker)
+    except ValueError:
+        return len(_TRACKER_ORDER)
+
+
 def _read_accuracy_csv(path):
     rows = []
     with open(path) as f:
@@ -189,6 +203,7 @@ def _plot_tracking_bars(ax, model_order, per_tracking, metric_key, label):
             offset = (idx - (n - 1) / 2) * (bar_width + gap)
             raw = per_tracking[(model_type, tracker)][metric_key]
             value = int(raw) if metric_key == "num_fragmentations" else float(raw)
+            hatch_idx = _hatch_index_for(tracker)
             ax.bar(
                 gi + offset,
                 value,
@@ -196,8 +211,8 @@ def _plot_tracking_bars(ax, model_order, per_tracking, metric_key, label):
                 color=color,
                 edgecolor=_INK,
                 linewidth=0.6,
-                hatch=_HATCHES[idx % len(_HATCHES)],
-                alpha=1.0 if idx == 0 else 0.7,
+                hatch=_HATCHES[hatch_idx % len(_HATCHES)],
+                alpha=1.0 if hatch_idx == 0 else 0.7,
             )
 
     ax.set_xticks(range(len(groups)))
@@ -238,10 +253,10 @@ def _add_tracker_legend(fig, per_tracking):
         Patch(
             facecolor="white",
             edgecolor=_INK,
-            hatch=_HATCHES[i % len(_HATCHES)],
+            hatch=_HATCHES[_hatch_index_for(tracker) % len(_HATCHES)],
             label=tracker,
         )
-        for i, tracker in enumerate(trackers_seen)
+        for tracker in trackers_seen
     ]
     fig.legend(
         handles=tracker_handles,

--- a/verification/tests/test_benchmark.py
+++ b/verification/tests/test_benchmark.py
@@ -335,6 +335,240 @@ class TestPerModelTrackingDefaults:
 
 
 # ---------------------------------------------------------------------------
+# _run_bytetrack_metrics — U5: --tracker bytetrack tracking-metrics path
+# ---------------------------------------------------------------------------
+
+
+def _boxes_from_centers(centers_by_frame, box_size=6.0, confidence=1.0):
+    """Build all_boxes_by_frame's {"xyxy", "confidence"} dict shape from a
+    dict of frame_idx -> list of (x, y) centers, for _run_bytetrack_metrics
+    test fixtures. Mirrors main()'s own detection-loop construction."""
+    result = {}
+    r = box_size / 2
+    for frame_idx, centers in centers_by_frame.items():
+        if not centers:
+            result[frame_idx] = {"xyxy": np.zeros((0, 4)), "confidence": np.zeros(0)}
+            continue
+        xyxy = np.array([[cx - r, cy - r, cx + r, cy + r] for cx, cy in centers])
+        result[frame_idx] = {
+            "xyxy": xyxy,
+            "confidence": np.full(len(centers), confidence, dtype=np.float64),
+        }
+    return result
+
+
+def _single_stationary_particle_gt_and_boxes(n_frames, x=100.0, y=100.0, box_size=6.0):
+    gt_rows = [{"frame": f, "particle_id": 1, "x": x, "y": y} for f in range(n_frames)]
+    all_boxes = _boxes_from_centers({f: [(x, y)] for f in range(n_frames)}, box_size=box_size)
+    return gt_rows, all_boxes
+
+
+class TestRunBytetrackMetrics:
+    """Parallel coverage to TestRunTrackingMetrics, for the --tracker
+    bytetrack path. Deliberately avoids asserting on ByteTrack's exact
+    confirmation-frame arithmetic (which differs by installed supervision
+    version -- see trackers-common's own U4 fix) -- assertions here stay
+    structural (non-null metrics, correct skip/degrade behavior), not tied
+    to a specific frame-by-frame confirmation timing."""
+
+    def test_stationary_particle_produces_real_metrics(self, tmp_path):
+        gt_rows, all_boxes = _single_stationary_particle_gt_and_boxes(10)
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, gt_rows)
+        cfg = _make_cfg()
+
+        result = benchmark._run_bytetrack_metrics(all_boxes, str(gt_path), cfg, "rf-detr")
+
+        assert result is not None
+        assert isinstance(result["mota"], float)
+        assert isinstance(result["idf1"], float)
+        assert "num_fragmentations" in result
+
+    def test_tracking_disabled_returns_none(self, tmp_path):
+        gt_rows, all_boxes = _single_stationary_particle_gt_and_boxes(3)
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, gt_rows)
+        cfg = _make_cfg(enabled=False)
+
+        result = benchmark._run_bytetrack_metrics(all_boxes, str(gt_path), cfg, "rf-detr")
+        assert result is None
+
+    def test_missing_gt_tracks_file_returns_none(self, tmp_path):
+        _, all_boxes = _single_stationary_particle_gt_and_boxes(3)
+        absent = str(tmp_path / "nonexistent.csv")
+        cfg = _make_cfg()
+
+        result = benchmark._run_bytetrack_metrics(all_boxes, absent, cfg, "rf-detr")
+        assert result is None
+
+    def test_missing_motmetrics_returns_none(self, tmp_path):
+        gt_rows, all_boxes = _single_stationary_particle_gt_and_boxes(3)
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, gt_rows)
+        cfg = _make_cfg()
+
+        with mock.patch.dict(sys.modules, {"motmetrics": None}):
+            result = benchmark._run_bytetrack_metrics(all_boxes, str(gt_path), cfg, "rf-detr")
+        assert result is None
+
+    def test_missing_supervision_returns_none(self, tmp_path):
+        gt_rows, all_boxes = _single_stationary_particle_gt_and_boxes(3)
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, gt_rows)
+        cfg = _make_cfg()
+
+        with mock.patch.dict(sys.modules, {"supervision": None}):
+            result = benchmark._run_bytetrack_metrics(all_boxes, str(gt_path), cfg, "rf-detr")
+        assert result is None
+
+    def test_no_detections_returns_none(self, tmp_path):
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, [{"frame": 0, "particle_id": 1, "x": 50.0, "y": 50.0}])
+        cfg = _make_cfg()
+
+        result = benchmark._run_bytetrack_metrics({}, str(gt_path), cfg, "rf-detr")
+        assert result is None
+
+    def test_tracking_metrics_csv_includes_threshold(self, tmp_path):
+        gt_rows, all_boxes = _single_stationary_particle_gt_and_boxes(5, x=100.0, y=100.0)
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, gt_rows)
+        cfg = _make_cfg(threshold_radii=0.75)
+
+        result = benchmark._run_bytetrack_metrics(all_boxes, str(gt_path), cfg, "rf-detr")
+
+        assert result is not None
+        assert result["matching_threshold_radii"] == pytest.approx(0.75)
+
+    def test_derived_psf_sigma_px_overrides_config_value(self, tmp_path):
+        gt_rows, all_boxes = _single_stationary_particle_gt_and_boxes(5, x=100.0, y=100.0)
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, gt_rows)
+        cfg = _make_cfg(psf_sigma=5.0, threshold_radii=0.5)
+
+        result = benchmark._run_bytetrack_metrics(
+            all_boxes, str(gt_path), cfg, "rf-detr", derived_psf_sigma_px=9.25
+        )
+
+        assert result is not None
+        assert result["psf_sigma_px"] == pytest.approx(9.25)
+        assert result["match_threshold_px"] == pytest.approx(0.5 * 9.25)
+
+
+class TestBytetrackTuningDefaults:
+    """R5/R9: ByteTrack's lost_track_buffer/minimum_consecutive_frames/
+    track_activation_threshold resolve through trackers_common.defaults the
+    same way trackpy's search_range/memory/stub_filter already do."""
+
+    def _captured_tuning(self, all_boxes, gt_path, cfg, model_type="rf-detr"):
+        import trackers_common.bytetrack as bytetrack_module
+
+        with mock.patch.object(
+            bytetrack_module, "run_bytetrack", wraps=bytetrack_module.run_bytetrack
+        ) as mock_run_bytetrack:
+            benchmark._run_bytetrack_metrics(all_boxes, str(gt_path), cfg, model_type)
+        args = mock_run_bytetrack.call_args.args
+        return {
+            "lost_track_buffer": args[1],
+            "minimum_consecutive_frames": args[2],
+            "track_activation_threshold": args[3],
+        }
+
+    def test_no_override_resolves_to_canonical_values(self, tmp_path):
+        gt_rows, all_boxes = _single_stationary_particle_gt_and_boxes(3)
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, gt_rows)
+        cfg = _cfg_no_tracking_overrides()
+
+        tuning = self._captured_tuning(all_boxes, gt_path, cfg)
+
+        assert tuning["lost_track_buffer"] == 60
+        assert tuning["minimum_consecutive_frames"] == 1
+        assert tuning["track_activation_threshold"] == pytest.approx(0.1)
+
+    def test_config_yaml_override_wins_over_canonical_default(self, tmp_path):
+        gt_rows, all_boxes = _single_stationary_particle_gt_and_boxes(3)
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, gt_rows)
+        cfg = _cfg_no_tracking_overrides()
+        cfg["tracking"]["lost_track_buffer"] = 5
+        cfg["tracking"]["minimum_consecutive_frames"] = 2
+        cfg["tracking"]["track_activation_threshold"] = 0.4
+
+        tuning = self._captured_tuning(all_boxes, gt_path, cfg)
+
+        assert tuning["lost_track_buffer"] == 5
+        assert tuning["minimum_consecutive_frames"] == 2
+        assert tuning["track_activation_threshold"] == pytest.approx(0.4)
+
+    def test_trackpy_model_type_falls_back_to_rf_detr_tuning(self, tmp_path):
+        gt_rows, all_boxes = _single_stationary_particle_gt_and_boxes(3)
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, gt_rows)
+        cfg = _cfg_no_tracking_overrides()
+
+        tuning = self._captured_tuning(all_boxes, gt_path, cfg, model_type="trackpy")
+
+        assert tuning["lost_track_buffer"] == 60
+        assert tuning["minimum_consecutive_frames"] == 1
+        assert tuning["track_activation_threshold"] == pytest.approx(0.1)
+
+
+class TestBytetrackFrameGapOrdering:
+    """Guards against the frame-position-vs-frame-index mismatch found during
+    review: main()'s detection loop can skip a frame_idx entirely (`if
+    frame_idx not in gt_by_frame: continue`), and run_bytetrack's
+    lost_track_buffer/minimum_consecutive_frames timing counts LIST
+    POSITIONS, not real frame_idx values -- so a missing frame_idx must
+    still occupy its own list position (an empty placeholder), not be
+    silently compacted into list-adjacency with its neighbors."""
+
+    def test_missing_frame_preserves_real_spacing_not_list_adjacency(self, tmp_path):
+        # frames 0, 1, 3 present; frame 2 entirely absent from
+        # all_boxes_by_frame (never accumulated, e.g. because it wasn't in
+        # ground_truth.json).
+        all_boxes = _boxes_from_centers({0: [(15.0, 15.0)], 1: [(15.0, 15.0)], 3: [(15.0, 15.0)]})
+        gt_rows = [{"frame": f, "particle_id": 1, "x": 15.0, "y": 15.0} for f in (0, 1, 3)]
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, gt_rows)
+        cfg = _cfg_no_tracking_overrides()
+
+        import trackers_common.bytetrack as bytetrack_module
+
+        with mock.patch.object(
+            bytetrack_module, "run_bytetrack", wraps=bytetrack_module.run_bytetrack
+        ) as mock_run_bytetrack:
+            benchmark._run_bytetrack_metrics(all_boxes, str(gt_path), cfg, "rf-detr")
+
+        detections_list = mock_run_bytetrack.call_args.args[0]
+        # 4 list entries (frame_idx 0, 1, 2, 3) -- not 3, which would put
+        # frame 3's detections immediately after frame 1's.
+        assert len(detections_list) == 4
+        assert len(detections_list[0]) == 1
+        assert len(detections_list[1]) == 1
+        assert len(detections_list[2]) == 0  # frame 2's empty placeholder
+        assert len(detections_list[3]) == 1
+
+    def test_no_gap_produces_one_entry_per_present_frame(self, tmp_path):
+        all_boxes = _boxes_from_centers({0: [(15.0, 15.0)], 1: [(15.0, 15.0)], 2: [(15.0, 15.0)]})
+        gt_rows = [{"frame": f, "particle_id": 1, "x": 15.0, "y": 15.0} for f in (0, 1, 2)]
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, gt_rows)
+        cfg = _cfg_no_tracking_overrides()
+
+        import trackers_common.bytetrack as bytetrack_module
+
+        with mock.patch.object(
+            bytetrack_module, "run_bytetrack", wraps=bytetrack_module.run_bytetrack
+        ) as mock_run_bytetrack:
+            benchmark._run_bytetrack_metrics(all_boxes, str(gt_path), cfg, "rf-detr")
+
+        detections_list = mock_run_bytetrack.call_args.args[0]
+        assert len(detections_list) == 3
+        assert all(len(d) == 1 for d in detections_list)
+
+
+# ---------------------------------------------------------------------------
 # _resolve_model_type — U1: pre-argparse model-type sniffing
 # ---------------------------------------------------------------------------
 
@@ -1080,6 +1314,279 @@ class TestMainModelTypeWiring:
 
         with pytest.raises(SystemExit):
             benchmark.main()
+
+
+# ---------------------------------------------------------------------------
+# main() — U5: --tracker {trackpy,bytetrack} dispatch and output filenames
+# ---------------------------------------------------------------------------
+
+
+def _fixed_result_dict(mota):
+    return {
+        "mota": mota,
+        "idf1": mota,
+        "num_fragmentations": 0,
+        "num_switches": 0,
+        "num_misses": 0,
+        "num_false_positives": 0,
+        "matching_threshold_radii": 0.5,
+        "psf_sigma_px": 5.0,
+        "match_threshold_px": 2.5,
+    }
+
+
+class TestMainTrackerDispatch:
+    """--tracker {trackpy,bytetrack} routing in main() -- R6/R7/AE1-AE3."""
+
+    def _rf_detr_argv(self, tmp_path, monkeypatch, tracker):
+        frames_dir = tmp_path / "frames"
+        if not frames_dir.exists():
+            _write_frames(frames_dir, n=1)
+        gt_path = tmp_path / "ground_truth.json"
+        if not gt_path.exists():
+            _write_ground_truth(gt_path, [[[10.0, 10.0]]])
+        gt_tracks_path = tmp_path / "ground_truth_tracks.csv"
+        if not gt_tracks_path.exists():
+            gt_tracks_path.write_text("frame,particle_id,x,y\n0,1,10.0,10.0\n")
+        checkpoint = tmp_path / "rfdetr_model.pth"
+        if not checkpoint.exists():
+            checkpoint.write_bytes(b"")
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            f"benchmark:\n  checkpoint: {checkpoint}\n  tiling:\n    enabled: false\n"
+        )
+
+        argv = [
+            "benchmark.py",
+            "--frames",
+            str(frames_dir),
+            "--ground-truth",
+            str(gt_path),
+            "--ground-truth-tracks",
+            str(gt_tracks_path),
+            "--config",
+            str(config_path),
+            "--model-type",
+            "rf-detr",
+            "--tracker",
+            tracker,
+        ]
+        monkeypatch.setattr(sys, "argv", argv)
+        monkeypatch.setattr(
+            benchmark, "_load_frame_rgb", lambda p: np.zeros((32, 32, 3), dtype=np.uint8)
+        )
+
+        fake_rfdetr_model = mock.Mock()
+        fake_rfdetr_model.predict.return_value = _sv_preload.Detections(
+            xyxy=np.array([[5.0, 5.0, 15.0, 15.0]], dtype=np.float32),
+            confidence=np.array([0.9], dtype=np.float32),
+            class_id=np.zeros(1, dtype=int),
+        )
+        return fake_rfdetr_model
+
+    def test_bytetrack_tracker_writes_suffixed_csv_with_real_metrics(self, tmp_path, monkeypatch):
+        """AE1: --tracker bytetrack --model-type rf-detr writes
+        tracking_metrics_rf-detr_bytetrack.csv with non-null MOTA/IDF1."""
+        monkeypatch.chdir(tmp_path)
+        fake_rfdetr_model = self._rf_detr_argv(tmp_path, monkeypatch, "bytetrack")
+
+        with mock.patch.object(benchmark, "get_rfdetr_model", return_value=fake_rfdetr_model):
+            benchmark.main()
+
+        csv_path = tmp_path / "verification_output" / "tracking_metrics_rf-detr_bytetrack.csv"
+        assert csv_path.exists()
+        with open(csv_path) as f:
+            row = next(csv.DictReader(f))
+        assert row["mota"] not in (None, "")
+        assert row["idf1"] not in (None, "")
+
+    def test_both_trackers_coexist_for_same_model(self, tmp_path, monkeypatch):
+        """AE2: a prior --tracker trackpy run's output file must still exist,
+        unmodified in name, after a subsequent --tracker bytetrack run for the
+        same --model-type -- neither overwrites the other."""
+        monkeypatch.chdir(tmp_path)
+
+        fake_rfdetr_model = self._rf_detr_argv(tmp_path, monkeypatch, "trackpy")
+        with mock.patch.object(
+            benchmark, "get_rfdetr_model", return_value=fake_rfdetr_model
+        ), mock.patch.object(
+            benchmark, "_run_tracking_metrics", return_value=_fixed_result_dict(1.0)
+        ):
+            benchmark.main()
+
+        fake_rfdetr_model = self._rf_detr_argv(tmp_path, monkeypatch, "bytetrack")
+        with mock.patch.object(
+            benchmark, "get_rfdetr_model", return_value=fake_rfdetr_model
+        ), mock.patch.object(
+            benchmark, "_run_bytetrack_metrics", return_value=_fixed_result_dict(0.5)
+        ):
+            benchmark.main()
+
+        trackpy_csv = tmp_path / "verification_output" / "tracking_metrics_rf-detr_trackpy.csv"
+        bytetrack_csv = tmp_path / "verification_output" / "tracking_metrics_rf-detr_bytetrack.csv"
+        assert trackpy_csv.exists()
+        assert bytetrack_csv.exists()
+        with open(trackpy_csv) as f:
+            trackpy_row = next(csv.DictReader(f))
+        with open(bytetrack_csv) as f:
+            bytetrack_row = next(csv.DictReader(f))
+        assert trackpy_row["mota"] != bytetrack_row["mota"]
+
+    def test_trackpy_detector_with_bytetrack_tracker_completes_without_raising(
+        self, tmp_path, monkeypatch
+    ):
+        """AE3: --model-type trackpy --tracker bytetrack previously raised
+        ValueError: Detections confidence must be provided for tracking. --
+        depends on U1's confidence fix already being in place."""
+        monkeypatch.chdir(tmp_path)
+        frames_dir = tmp_path / "frames"
+        _write_frames(frames_dir, n=1)
+        gt_path = tmp_path / "ground_truth.json"
+        _write_ground_truth(gt_path, [[[10.0, 10.0]]])
+        gt_tracks_path = tmp_path / "ground_truth_tracks.csv"
+        gt_tracks_path.write_text("frame,particle_id,x,y\n0,1,10.0,10.0\n")
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("benchmark:\n  trackpy:\n    diameter: 11\n")
+
+        argv = [
+            "benchmark.py",
+            "--frames",
+            str(frames_dir),
+            "--ground-truth",
+            str(gt_path),
+            "--ground-truth-tracks",
+            str(gt_tracks_path),
+            "--config",
+            str(config_path),
+            "--model-type",
+            "trackpy",
+            "--tracker",
+            "bytetrack",
+        ]
+        monkeypatch.setattr(sys, "argv", argv)
+        monkeypatch.setattr(
+            benchmark, "_load_frame_rgb", lambda p: np.zeros((32, 32, 3), dtype=np.uint8)
+        )
+        # Matches detect_trackpy's own U1 default shape (confidence always set).
+        fake_detections = _sv_preload.Detections(
+            xyxy=np.array([[5.0, 5.0, 15.0, 15.0]], dtype=np.float64),
+            class_id=np.zeros(1, dtype=int),
+            confidence=np.ones(1),
+        )
+
+        with mock.patch.object(benchmark, "detect_trackpy", return_value=fake_detections):
+            benchmark.main()  # must not raise
+
+        csv_path = tmp_path / "verification_output" / "tracking_metrics_trackpy_bytetrack.csv"
+        assert csv_path.exists()
+
+    def test_default_tracker_is_trackpy_and_filename_carries_suffix(self, tmp_path, monkeypatch):
+        """R6 default preserves current behavior; filename gains the
+        deliberate one-time _trackpy suffix (KTD: uniform naming scheme for
+        both trackers)."""
+        monkeypatch.chdir(tmp_path)
+        frames_dir = tmp_path / "frames"
+        _write_frames(frames_dir, n=1)
+        gt_path = tmp_path / "ground_truth.json"
+        _write_ground_truth(gt_path, [[[10.0, 10.0]]])
+        gt_tracks_path = tmp_path / "ground_truth_tracks.csv"
+        gt_tracks_path.write_text("frame,particle_id,x,y\n0,1,10.0,10.0\n")
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("benchmark:\n  trackpy:\n    diameter: 11\n")
+
+        argv = [
+            "benchmark.py",
+            "--frames",
+            str(frames_dir),
+            "--ground-truth",
+            str(gt_path),
+            "--ground-truth-tracks",
+            str(gt_tracks_path),
+            "--config",
+            str(config_path),
+            "--model-type",
+            "trackpy",
+            # --tracker intentionally omitted -- must default to trackpy
+        ]
+        monkeypatch.setattr(sys, "argv", argv)
+        monkeypatch.setattr(
+            benchmark, "_load_frame_rgb", lambda p: np.zeros((32, 32, 3), dtype=np.uint8)
+        )
+
+        with mock.patch.object(
+            benchmark, "detect_trackpy", return_value=_sv_preload.Detections.empty()
+        ), mock.patch.object(
+            benchmark, "_run_tracking_metrics", return_value=_fixed_result_dict(1.0)
+        ) as mock_tracking_metrics, mock.patch.object(
+            benchmark, "_run_bytetrack_metrics"
+        ) as mock_bytetrack_metrics:
+            benchmark.main()
+
+        mock_tracking_metrics.assert_called_once()
+        mock_bytetrack_metrics.assert_not_called()
+        assert (tmp_path / "verification_output" / "tracking_metrics_trackpy_trackpy.csv").exists()
+
+    def test_accuracy_metrics_unaffected_by_tracker_choice(self, tmp_path, monkeypatch):
+        """Regression guard for U5's all_boxes_by_frame extension (Risks
+        section): accuracy_metrics_*.csv content must be identical
+        regardless of --tracker, since the detection-accuracy computation
+        that writes it is untouched by this unit except for the additive
+        all_boxes_by_frame accumulation running alongside it."""
+
+        def _run(tracker, subdir):
+            out_dir = tmp_path / subdir
+            out_dir.mkdir()
+            monkeypatch.chdir(out_dir)
+            frames_dir = out_dir / "frames"
+            _write_frames(frames_dir, n=3)
+            gt_path = out_dir / "ground_truth.json"
+            _write_ground_truth(gt_path, [[[10.0, 10.0]], [[11.0, 11.0]], [[12.0, 12.0]]])
+            gt_tracks_path = out_dir / "ground_truth_tracks.csv"
+            gt_tracks_path.write_text(
+                "frame,particle_id,x,y\n0,1,10.0,10.0\n1,1,11.0,11.0\n2,1,12.0,12.0\n"
+            )
+            config_path = out_dir / "config.yaml"
+            config_path.write_text("benchmark:\n  trackpy:\n    diameter: 11\n")
+
+            argv = [
+                "benchmark.py",
+                "--frames",
+                str(frames_dir),
+                "--ground-truth",
+                str(gt_path),
+                "--ground-truth-tracks",
+                str(gt_tracks_path),
+                "--config",
+                str(config_path),
+                "--model-type",
+                "trackpy",
+                "--tracker",
+                tracker,
+            ]
+            monkeypatch.setattr(sys, "argv", argv)
+            monkeypatch.setattr(
+                benchmark, "_load_frame_rgb", lambda p: np.zeros((32, 32, 3), dtype=np.uint8)
+            )
+            fake_detections = _sv_preload.Detections(
+                xyxy=np.array([[5.0, 5.0, 15.0, 15.0]], dtype=np.float64),
+                class_id=np.zeros(1, dtype=int),
+                confidence=np.ones(1),
+            )
+            with mock.patch.object(
+                benchmark, "detect_trackpy", return_value=fake_detections
+            ), mock.patch.object(
+                benchmark, "_run_tracking_metrics", return_value=None
+            ), mock.patch.object(
+                benchmark, "_run_bytetrack_metrics", return_value=None
+            ):
+                benchmark.main()
+
+            return (out_dir / "verification_output" / "accuracy_metrics_trackpy.csv").read_text()
+
+        trackpy_output = _run("trackpy", "run_trackpy")
+        bytetrack_output = _run("bytetrack", "run_bytetrack")
+
+        assert trackpy_output == bytetrack_output
 
 
 class TestLodestarBoxSizeDerivation:

--- a/verification/tests/test_benchmark.py
+++ b/verification/tests/test_benchmark.py
@@ -539,7 +539,10 @@ class TestBytetrackTuningDefaults:
         assert tuning["minimum_consecutive_frames"] == 2
         assert tuning["track_activation_threshold"] == pytest.approx(0.4)
 
-    def test_trackpy_model_type_falls_back_to_rf_detr_tuning(self, tmp_path):
+    def test_trackpy_model_type_uses_own_divergent_tuning(self, tmp_path):
+        # trackpy's own sweep (2026-08-19) found minimum_consecutive_frames=3
+        # measurably better than rf-detr/yolo's mcf=1 optimum -- it has its
+        # own explicit tracker_defaults.yaml entry now, not a fallback.
         gt_rows, all_boxes = _single_stationary_particle_gt_and_boxes(3)
         gt_path = tmp_path / "gt.csv"
         _write_gt_tracks(gt_path, gt_rows)
@@ -548,7 +551,7 @@ class TestBytetrackTuningDefaults:
         tuning = self._captured_tuning(all_boxes, gt_path, cfg, model_type="trackpy")
 
         assert tuning["lost_track_buffer"] == 30
-        assert tuning["minimum_consecutive_frames"] == 1
+        assert tuning["minimum_consecutive_frames"] == 3
         assert tuning["track_activation_threshold"] == pytest.approx(0.3)
 
 
@@ -1504,14 +1507,28 @@ class TestMainTrackerDispatch:
     ):
         """AE3: --model-type trackpy --tracker bytetrack previously raised
         ValueError: Detections confidence must be provided for tracking. --
-        depends on U1's confidence fix already being in place."""
+        depends on U1's confidence fix already being in place. Uses 5 frames
+        (empty frame 0, then 4 consecutive detections) because trackpy's own
+        tuning now requires minimum_consecutive_frames=3 before ByteTrack
+        confirms a track (see tracker_defaults.yaml): a detection on the
+        tracker's very first-ever frame confirms immediately regardless of
+        minimum_consecutive_frames, so frame 0 must be empty to actually
+        exercise the 3-consecutive-frame requirement. verification's pinned
+        supervision (0.30.0) confirms one frame later than trackers-common's
+        pinned supervision (0.29.0) for the same minimum_consecutive_frames
+        -- confirmed empirically confirms at the 4th consecutive present
+        frame here, not the 3rd as trackers-common's own characterization
+        test shows for its own (older) pinned version -- so this needs one
+        more present frame than a same-package equivalent would."""
         monkeypatch.chdir(tmp_path)
         frames_dir = tmp_path / "frames"
-        _write_frames(frames_dir, n=1)
+        _write_frames(frames_dir, n=5)
         gt_path = tmp_path / "ground_truth.json"
-        _write_ground_truth(gt_path, [[[10.0, 10.0]]])
+        _write_ground_truth(gt_path, [[]] + [[[10.0, 10.0]]] * 4)
         gt_tracks_path = tmp_path / "ground_truth_tracks.csv"
-        gt_tracks_path.write_text("frame,particle_id,x,y\n0,1,10.0,10.0\n")
+        gt_tracks_path.write_text(
+            "frame,particle_id,x,y\n1,1,10.0,10.0\n2,1,10.0,10.0\n3,1,10.0,10.0\n4,1,10.0,10.0\n"
+        )
         config_path = tmp_path / "config.yaml"
         config_path.write_text("benchmark:\n  trackpy:\n    diameter: 11\n")
 
@@ -1540,8 +1557,17 @@ class TestMainTrackerDispatch:
             class_id=np.zeros(1, dtype=int),
             confidence=np.ones(1),
         )
+        # Frame 0 empty, frames 1-4 detect -- see docstring for why frame 0
+        # must be empty and why 4 (not 3) consecutive detections are needed.
+        detections_by_frame = [
+            _sv_preload.Detections.empty(),
+            fake_detections,
+            fake_detections,
+            fake_detections,
+            fake_detections,
+        ]
 
-        with mock.patch.object(benchmark, "detect_trackpy", return_value=fake_detections):
+        with mock.patch.object(benchmark, "detect_trackpy", side_effect=detections_by_frame):
             benchmark.main()  # must not raise
 
         csv_path = tmp_path / "verification_output" / "tracking_metrics_trackpy_bytetrack.csv"

--- a/verification/tests/test_benchmark.py
+++ b/verification/tests/test_benchmark.py
@@ -454,23 +454,28 @@ class TestRunBytetrackMetrics:
         assert result["psf_sigma_px"] == pytest.approx(9.25)
         assert result["match_threshold_px"] == pytest.approx(0.5 * 9.25)
 
-    def test_high_raw_density_skips_before_running_bytetrack(self, tmp_path):
-        """Density pre-check must fire on RAW per-frame box count, before
-        run_bytetrack is ever called -- not only after tracking completes,
-        which would waste the full timeout window on input already known to
-        exceed the safe threshold (found during review: performance)."""
+    def test_high_raw_density_still_runs_bytetrack_not_skipped(self, tmp_path):
+        """No raw-density pre-check gates run_bytetrack -- an earlier version
+        of this function skipped above 400 det/frame, copied unvalidated from
+        trackpy's own accumulator-protection threshold. Measured directly
+        against this repo's real dataset (~1167-1446 det/frame, temporally
+        coherent), run_bytetrack completes in ~18s, nowhere near the 90s
+        timeout budget -- the pre-check was blocking the feature from ever
+        running on this project's actual data. This guards against
+        reintroducing that regression: 401 detections/frame (would have
+        tripped the old 400 threshold) must still reach run_bytetrack."""
         gt_path = tmp_path / "gt.csv"
         _write_gt_tracks(gt_path, [{"frame": 0, "particle_id": 1, "x": 100.0, "y": 100.0}])
-        # 401 detections in a single frame -- over the 400/frame threshold.
         centers = [(100.0 + i, 100.0) for i in range(401)]
         all_boxes = _boxes_from_centers({0: centers})
         cfg = _make_cfg()
 
-        with mock.patch("trackers_common.bytetrack.run_bytetrack") as mock_run_bytetrack:
-            result = benchmark._run_bytetrack_metrics(all_boxes, str(gt_path), cfg, "rf-detr")
+        with mock.patch(
+            "trackers_common.bytetrack.run_bytetrack", wraps=lambda *a, **kw: []
+        ) as mock_run_bytetrack:
+            benchmark._run_bytetrack_metrics(all_boxes, str(gt_path), cfg, "rf-detr")
 
-        assert result is None
-        mock_run_bytetrack.assert_not_called()
+        mock_run_bytetrack.assert_called_once()
 
     def test_memory_error_from_run_bytetrack_degrades_to_none(self, tmp_path):
         """A MemoryError from the in-process, unisolated ByteTrack call must

--- a/verification/tests/test_benchmark.py
+++ b/verification/tests/test_benchmark.py
@@ -454,6 +454,39 @@ class TestRunBytetrackMetrics:
         assert result["psf_sigma_px"] == pytest.approx(9.25)
         assert result["match_threshold_px"] == pytest.approx(0.5 * 9.25)
 
+    def test_high_raw_density_skips_before_running_bytetrack(self, tmp_path):
+        """Density pre-check must fire on RAW per-frame box count, before
+        run_bytetrack is ever called -- not only after tracking completes,
+        which would waste the full timeout window on input already known to
+        exceed the safe threshold (found during review: performance)."""
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, [{"frame": 0, "particle_id": 1, "x": 100.0, "y": 100.0}])
+        # 401 detections in a single frame -- over the 400/frame threshold.
+        centers = [(100.0 + i, 100.0) for i in range(401)]
+        all_boxes = _boxes_from_centers({0: centers})
+        cfg = _make_cfg()
+
+        with mock.patch("trackers_common.bytetrack.run_bytetrack") as mock_run_bytetrack:
+            result = benchmark._run_bytetrack_metrics(all_boxes, str(gt_path), cfg, "rf-detr")
+
+        assert result is None
+        mock_run_bytetrack.assert_not_called()
+
+    def test_memory_error_from_run_bytetrack_degrades_to_none(self, tmp_path):
+        """A MemoryError from the in-process, unisolated ByteTrack call must
+        degrade to a warning + None, the same as a timeout -- not propagate
+        and crash the whole benchmark.py process (found during review:
+        adversarial, reliability)."""
+        gt_rows, all_boxes = _single_stationary_particle_gt_and_boxes(3)
+        gt_path = tmp_path / "gt.csv"
+        _write_gt_tracks(gt_path, gt_rows)
+        cfg = _make_cfg()
+
+        with mock.patch("trackers_common.bytetrack.run_bytetrack", side_effect=MemoryError):
+            result = benchmark._run_bytetrack_metrics(all_boxes, str(gt_path), cfg, "rf-detr")
+
+        assert result is None
+
 
 class TestBytetrackTuningDefaults:
     """R5/R9: ByteTrack's lost_track_buffer/minimum_consecutive_frames/

--- a/verification/tests/test_benchmark.py
+++ b/verification/tests/test_benchmark.py
@@ -1583,10 +1583,20 @@ class TestMainTrackerDispatch:
 
             return (out_dir / "verification_output" / "accuracy_metrics_trackpy.csv").read_text()
 
+        def _strip_inference_time_column(csv_text):
+            # inference_time_ms is real per-frame wall-clock timing (added
+            # independently of --tracker) -- it legitimately varies between
+            # two separate runs and isn't part of what this test guards.
+            rows = [row.split(",") for row in csv_text.strip().splitlines()]
+            idx = rows[0].index("inference_time_ms")
+            return [row[:idx] + row[idx + 1 :] for row in rows]
+
         trackpy_output = _run("trackpy", "run_trackpy")
         bytetrack_output = _run("bytetrack", "run_bytetrack")
 
-        assert trackpy_output == bytetrack_output
+        assert _strip_inference_time_column(trackpy_output) == _strip_inference_time_column(
+            bytetrack_output
+        )
 
 
 class TestLodestarBoxSizeDerivation:

--- a/verification/tests/test_benchmark.py
+++ b/verification/tests/test_benchmark.py
@@ -520,9 +520,9 @@ class TestBytetrackTuningDefaults:
 
         tuning = self._captured_tuning(all_boxes, gt_path, cfg)
 
-        assert tuning["lost_track_buffer"] == 60
+        assert tuning["lost_track_buffer"] == 30
         assert tuning["minimum_consecutive_frames"] == 1
-        assert tuning["track_activation_threshold"] == pytest.approx(0.1)
+        assert tuning["track_activation_threshold"] == pytest.approx(0.3)
 
     def test_config_yaml_override_wins_over_canonical_default(self, tmp_path):
         gt_rows, all_boxes = _single_stationary_particle_gt_and_boxes(3)
@@ -547,9 +547,9 @@ class TestBytetrackTuningDefaults:
 
         tuning = self._captured_tuning(all_boxes, gt_path, cfg, model_type="trackpy")
 
-        assert tuning["lost_track_buffer"] == 60
+        assert tuning["lost_track_buffer"] == 30
         assert tuning["minimum_consecutive_frames"] == 1
-        assert tuning["track_activation_threshold"] == pytest.approx(0.1)
+        assert tuning["track_activation_threshold"] == pytest.approx(0.3)
 
 
 class TestBytetrackFrameGapOrdering:
@@ -909,6 +909,35 @@ def _make_gaussian_blob_frame(size=64, center=(32, 32), sigma=3.0, peak=200.0):
     gray = peak * np.exp(-(((xx - cx) ** 2 + (yy - cy) ** 2) / (2 * sigma**2)))
     gray = gray.clip(0, 255).astype(np.uint8)
     return np.stack([gray, gray, gray], axis=-1)
+
+
+class TestResolveMatchDistance:
+    """Accuracy's match_distance must derive from the same
+    tracking.matching_threshold_radii x psf_sigma_px formula the tracking
+    metrics use -- not a disconnected literal (found while investigating
+    real benchmark results: a detection could count as accurate under a
+    loose radius while failing tracking's stricter identity match purely
+    from normal localization jitter, not a real disagreement)."""
+
+    def test_derives_from_threshold_radii_times_psf_sigma(self):
+        full_cfg = {"tracking": {"matching_threshold_radii": 0.5}, "synthetic": {"psf_sigma": 5.0}}
+        assert benchmark._resolve_match_distance({}, full_cfg) == pytest.approx(2.5)
+
+    def test_explicit_config_value_wins_over_derived(self):
+        full_cfg = {"tracking": {"matching_threshold_radii": 0.5}, "synthetic": {"psf_sigma": 5.0}}
+        cfg = {"match_distance": 12}
+        assert benchmark._resolve_match_distance(cfg, full_cfg) == 12
+
+    def test_missing_threshold_radii_falls_back_to_default_0_5(self):
+        full_cfg = {"synthetic": {"psf_sigma": 4.0}}
+        assert benchmark._resolve_match_distance({}, full_cfg) == pytest.approx(2.0)
+
+    def test_deeptrack_psf_sigma_px_path_also_used(self):
+        full_cfg = {
+            "tracking": {"matching_threshold_radii": 1.0},
+            "synthetic": {"psf": {"sigma_px": 3.0}},
+        }
+        assert benchmark._resolve_match_distance({}, full_cfg) == pytest.approx(3.0)
 
 
 class TestDetectTrackpy:

--- a/verification/tests/test_plot_benchmark.py
+++ b/verification/tests/test_plot_benchmark.py
@@ -1,15 +1,237 @@
-"""Tests for plot_benchmark.py -- the run-level 4-way comparison chart."""
+"""Tests for plot_benchmark.py -- both the per-frame line/tracker-bar
+comparison figure (benchmark_comparison.png) and the run-level 4-way summary
+figure (benchmark_summary.png).
+
+docs/plans/2026-08-18-001-feat-bytetrack-tracking-support-plan.md U6 test
+scenarios:
+- two tracker CSVs present for one model_type produce two bars (one per
+  tracker) in the tracking bar panel, plus a two-row stdout entry
+- only one tracker CSV present for a model_type produces one bar without
+  erroring on the missing counterpart
+- no tracking_metrics_*.csv files at all: the tracking bar panel renders an
+  empty state, the rest of the plot (line panels) still renders
+- the existing --models CLI filter restricts which model_types appear in
+  both the line panels and the new bar panel
+"""
 
 import csv
 import sys
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-import plot_benchmark
+import plot_benchmark as pb
 
 
-def _write_accuracy_csv(path, rows):
+def _write_accuracy_csv(path, model_type, n_frames=3):
+    """Write a minimal accuracy_metrics_{model_type}.csv with the columns
+    _read_accuracy_csv/_aggregate_from_csv expect (no inference_time_ms --
+    see _write_accuracy_csv_rows for that)."""
+    with open(path / f"accuracy_metrics_{model_type}.csv", "w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "frame",
+                "precision",
+                "recall",
+                "f1",
+                "mean_pos_error_px",
+                "n_tp",
+                "n_fp",
+                "n_fn",
+            ],
+        )
+        writer.writeheader()
+        for frame in range(n_frames):
+            writer.writerow(
+                {
+                    "frame": frame,
+                    "precision": 0.9,
+                    "recall": 0.8,
+                    "f1": 0.85,
+                    "mean_pos_error_px": 1.5,
+                    "n_tp": 10,
+                    "n_fp": 1,
+                    "n_fn": 2,
+                }
+            )
+
+
+def _write_tracking_csv(path, model_type, tracker, mota=0.5, idf1=0.6, num_fragmentations=10):
+    """Write a tracking_metrics_{model_type}_{tracker}.csv matching the single
+    aggregate-row schema benchmark.py's _run_tracking_metrics/
+    _run_bytetrack_metrics write (mota/idf1/num_fragmentations/num_switches/
+    num_misses/num_false_positives, plus threshold metadata)."""
+    with open(path / f"tracking_metrics_{model_type}_{tracker}.csv", "w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "mota",
+                "idf1",
+                "num_fragmentations",
+                "num_switches",
+                "num_misses",
+                "num_false_positives",
+                "matching_threshold_radii",
+                "psf_sigma_px",
+                "match_threshold_px",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "mota": mota,
+                "idf1": idf1,
+                "num_fragmentations": num_fragmentations,
+                "num_switches": 3,
+                "num_misses": 100,
+                "num_false_positives": 5,
+                "matching_threshold_radii": 0.5,
+                "psf_sigma_px": 5.0,
+                "match_threshold_px": 2.5,
+            }
+        )
+
+
+def _run_main(output_dir, models=None):
+    argv = ["plot_benchmark.py", "--output-dir", str(output_dir)]
+    if models:
+        argv += ["--models", *models]
+    with mock.patch.object(sys, "argv", argv):
+        pb.main()
+
+
+class TestTwoTrackersPresent:
+    def test_two_tracker_csvs_produce_two_bars(self, tmp_path, capsys):
+        _write_accuracy_csv(tmp_path, "rf-detr")
+        _write_tracking_csv(tmp_path, "rf-detr", "trackpy", mota=0.7)
+        _write_tracking_csv(tmp_path, "rf-detr", "bytetrack", mota=0.4)
+
+        _run_main(tmp_path)
+
+        out = capsys.readouterr().out
+        assert "rf-detr    trackpy" in out
+        assert "rf-detr    bytetrack" in out
+
+        png_path = tmp_path / "benchmark_comparison.png"
+        assert png_path.exists()
+        assert png_path.stat().st_size > 0
+
+    def test_bar_panel_helper_draws_two_bars_for_two_trackers(self):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        per_tracking = {
+            ("rf-detr", "trackpy"): {"mota": "0.7"},
+            ("rf-detr", "bytetrack"): {"mota": "0.4"},
+        }
+        pb._plot_tracking_bars(ax, ["rf-detr"], per_tracking, "mota", "MOTA")
+        # One bar (Rectangle patch) per tracker present for the single group.
+        assert len(ax.patches) == 2
+        plt.close(fig)
+
+
+class TestSingleTrackerPresent:
+    def test_single_tracker_csv_produces_one_bar_no_crash(self, tmp_path, capsys):
+        _write_accuracy_csv(tmp_path, "rf-detr")
+        _write_tracking_csv(tmp_path, "rf-detr", "trackpy")
+
+        _run_main(tmp_path)
+
+        out = capsys.readouterr().out
+        assert "rf-detr    trackpy" in out
+        assert "bytetrack" not in out
+        assert (tmp_path / "benchmark_comparison.png").exists()
+
+    def test_bar_panel_helper_draws_one_bar_for_one_tracker(self):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        per_tracking = {("rf-detr", "trackpy"): {"mota": "0.7"}}
+        pb._plot_tracking_bars(ax, ["rf-detr"], per_tracking, "mota", "MOTA")
+        assert len(ax.patches) == 1
+        plt.close(fig)
+
+
+class TestNoTrackingCsvsPresent:
+    def test_no_tracking_csvs_omits_bar_panel_without_error(self, tmp_path, capsys):
+        _write_accuracy_csv(tmp_path, "rf-detr")
+        _write_accuracy_csv(tmp_path, "yolo")
+
+        _run_main(tmp_path)
+
+        out = capsys.readouterr().out
+        # No tracking table header at all when nothing is present.
+        assert "tracker" not in out
+        assert "mota" not in out
+        # Line-panel summary table is unaffected.
+        assert "rf-detr" in out
+        assert "yolo" in out
+        assert (tmp_path / "benchmark_comparison.png").exists()
+
+    def test_bar_panel_helper_shows_empty_state(self):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        pb._plot_tracking_bars(ax, ["rf-detr", "yolo"], {}, "mota", "MOTA")
+        assert len(ax.patches) == 0
+        assert len(ax.texts) == 1
+        assert "no tracking metrics" in ax.texts[0].get_text()
+        plt.close(fig)
+
+
+class TestModelsFilterAppliesToBarPanel:
+    def test_models_filter_restricts_bar_panel_groups(self, tmp_path, capsys):
+        _write_accuracy_csv(tmp_path, "rf-detr")
+        _write_accuracy_csv(tmp_path, "trackpy")
+        _write_tracking_csv(tmp_path, "rf-detr", "trackpy")
+        _write_tracking_csv(tmp_path, "trackpy", "bytetrack")
+
+        _run_main(tmp_path, models=["rf-detr"])
+
+        out = capsys.readouterr().out
+        assert "rf-detr" in out
+        assert "trackpy" not in out.split("\n\n")[0]  # line-panel table excludes it
+        # Tracking table should only mention rf-detr's row, not trackpy's.
+        tracking_section = out.split("mota")[-1] if "mota" in out else ""
+        assert "bytetrack" not in tracking_section
+
+    def test_discovery_only_globs_filtered_model_types(self, tmp_path):
+        _write_accuracy_csv(tmp_path, "rf-detr")
+        _write_accuracy_csv(tmp_path, "trackpy")
+        _write_tracking_csv(tmp_path, "rf-detr", "trackpy")
+        _write_tracking_csv(tmp_path, "trackpy", "bytetrack")
+
+        _run_main(tmp_path, models=["rf-detr"])
+        # Re-run discovery logic directly to check per_tracking keys precisely
+        # by re-invoking main() would print; instead verify via the glob
+        # pattern plot_benchmark.py itself uses for the filtered model only.
+        prefix = "tracking_metrics_rf-detr_"
+        matches = sorted(tmp_path.glob(f"{prefix}*.csv"))
+        assert len(matches) == 1
+        assert matches[0].name == "tracking_metrics_rf-detr_trackpy.csv"
+
+
+class TestTrackerSortKey:
+    def test_known_trackers_sort_before_unknown(self):
+        trackers = sorted(["bytetrack", "unknown-tracker", "trackpy"], key=pb._tracker_sort_key)
+        assert trackers == ["trackpy", "bytetrack", "unknown-tracker"]
+
+
+# --- benchmark_summary.png: the run-level 4-way comparison chart ---
+
+
+def _write_accuracy_csv_rows(path, rows):
     fieldnames = [
         "frame",
         "n_gt",
@@ -51,12 +273,12 @@ def _row(frame, tp=8, fp=1, fn=1, err=1.5, inference_ms=10.0):
 class TestAggregateFromCsv:
     def test_computes_mean_and_median_inference_time(self, tmp_path):
         csv_path = tmp_path / "accuracy_metrics_trackpy.csv"
-        _write_accuracy_csv(
+        _write_accuracy_csv_rows(
             csv_path,
             [_row(0, inference_ms=10.0), _row(1, inference_ms=20.0), _row(2, inference_ms=30.0)],
         )
 
-        result = plot_benchmark._aggregate_from_csv(csv_path)
+        result = pb._aggregate_from_csv(csv_path)
 
         assert result["mean_inference_ms"] == 20.0
         assert result["median_inference_ms"] == 20.0
@@ -97,7 +319,7 @@ class TestAggregateFromCsv:
                 }
             )
 
-        result = plot_benchmark._aggregate_from_csv(csv_path)
+        result = pb._aggregate_from_csv(csv_path)
 
         assert result["mean_inference_ms"] is None
         assert result["median_inference_ms"] is None
@@ -108,13 +330,13 @@ class TestMainEndToEnd:
         monkeypatch.chdir(tmp_path)
         out_dir = tmp_path / "verification_output"
         out_dir.mkdir()
-        _write_accuracy_csv(
+        _write_accuracy_csv_rows(
             out_dir / "accuracy_metrics_trackpy.csv",
             [_row(i, inference_ms=10.0 + i) for i in range(5)],
         )
 
         monkeypatch.setattr(sys, "argv", ["plot_benchmark.py", "--output-dir", str(out_dir)])
-        plot_benchmark.main()
+        pb.main()
 
         assert (out_dir / "benchmark_comparison.png").exists()
         assert (out_dir / "benchmark_summary.png").exists()
@@ -127,19 +349,16 @@ class TestMainEndToEnd:
         monkeypatch.chdir(tmp_path)
         out_dir = tmp_path / "verification_output"
         out_dir.mkdir()
-        _write_accuracy_csv(
+        _write_accuracy_csv_rows(
             out_dir / "accuracy_metrics_rf-detr.csv",
             [_row(i, inference_ms=50.0 + i) for i in range(5)],
         )
-        with open(out_dir / "tracking_metrics_rf-detr.csv", "w", newline="") as f:
-            writer = csv.DictWriter(
-                f, fieldnames=["mota", "idf1", "num_fragmentations", "num_switches"]
-            )
-            writer.writeheader()
-            writer.writerow({"mota": 0.5, "idf1": 0.6, "num_fragmentations": 12, "num_switches": 3})
+        # benchmark_summary.png's tracking panels use each model's trackpy
+        # result specifically -- see _plot_summary_bars's own docstring.
+        _write_tracking_csv(out_dir, "rf-detr", "trackpy", mota=0.5, idf1=0.6, num_fragmentations=12)
 
         monkeypatch.setattr(sys, "argv", ["plot_benchmark.py", "--output-dir", str(out_dir)])
-        plot_benchmark.main()
+        pb.main()
 
         captured = capsys.readouterr()
         assert "mota" in captured.out
@@ -151,19 +370,16 @@ class TestMainEndToEnd:
         out_dir = tmp_path / "verification_output"
         out_dir.mkdir()
         for model_type in ("rf-detr", "lodestar", "trackpy", "yolo"):
-            _write_accuracy_csv(
+            _write_accuracy_csv_rows(
                 out_dir / f"accuracy_metrics_{model_type}.csv",
                 [_row(i, inference_ms=10.0) for i in range(3)],
             )
 
         monkeypatch.setattr(sys, "argv", ["plot_benchmark.py", "--output-dir", str(out_dir)])
-        plot_benchmark.main()
+        pb.main()
 
         assert (out_dir / "benchmark_summary.png").exists()
         # Every known model type keeps its own fixed color, never reassigned.
-        seen = list(plot_benchmark._MODEL_COLORS.keys())
+        seen = list(pb._MODEL_COLORS.keys())
         for model_type in ("rf-detr", "lodestar", "trackpy", "yolo"):
-            assert (
-                plot_benchmark._color_for(model_type, seen)
-                == plot_benchmark._MODEL_COLORS[model_type]
-            )
+            assert pb._color_for(model_type, seen) == pb._MODEL_COLORS[model_type]

--- a/verification/tests/test_plot_benchmark.py
+++ b/verification/tests/test_plot_benchmark.py
@@ -386,7 +386,9 @@ class TestMainEndToEnd:
         )
         # benchmark_summary.png's tracking panels use each model's trackpy
         # result specifically -- see _plot_summary_bars's own docstring.
-        _write_tracking_csv(out_dir, "rf-detr", "trackpy", mota=0.5, idf1=0.6, num_fragmentations=12)
+        _write_tracking_csv(
+            out_dir, "rf-detr", "trackpy", mota=0.5, idf1=0.6, num_fragmentations=12
+        )
 
         monkeypatch.setattr(sys, "argv", ["plot_benchmark.py", "--output-dir", str(out_dir)])
         pb.main()

--- a/verification/tests/test_plot_benchmark.py
+++ b/verification/tests/test_plot_benchmark.py
@@ -135,6 +135,37 @@ class TestTwoTrackersPresent:
         plt.close(fig)
 
 
+class TestHatchIndexIsGlobalNotPerGroup:
+    """A model group with only 'bytetrack' present must still use
+    bytetrack's fixed global hatch/alpha, not the local enumerate()
+    position within that group's own (shorter) tracker subset -- otherwise
+    its bar would be styled identically to a 'trackpy' bar elsewhere on the
+    same figure while the legend claims the two hatches mean different
+    things (found during review: correctness)."""
+
+    def test_hatch_index_fixed_by_tracker_order_not_local_position(self):
+        assert pb._hatch_index_for("trackpy") == 0
+        assert pb._hatch_index_for("bytetrack") == 1
+
+    def test_bytetrack_only_group_uses_bytetrack_hatch_not_index_zero(self):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        # rf-detr has ONLY bytetrack present (no trackpy) -- its bar's
+        # local enumerate() index would be 0, but bytetrack's fixed global
+        # hatch index is 1.
+        per_tracking = {("rf-detr", "bytetrack"): {"mota": "0.4"}}
+        pb._plot_tracking_bars(ax, ["rf-detr"], per_tracking, "mota", "MOTA")
+
+        assert len(ax.patches) == 1
+        assert ax.patches[0].get_hatch() == pb._HATCHES[pb._hatch_index_for("bytetrack")]
+        assert ax.patches[0].get_hatch() != pb._HATCHES[pb._hatch_index_for("trackpy")]
+        plt.close(fig)
+
+
 class TestSingleTrackerPresent:
     def test_single_tracker_csv_produces_one_bar_no_crash(self, tmp_path, capsys):
         _write_accuracy_csv(tmp_path, "rf-detr")

--- a/verification/uv.lock
+++ b/verification/uv.lock
@@ -1329,6 +1329,7 @@ dependencies = [
     { name = "motmetrics" },
     { name = "pandas" },
     { name = "pyyaml" },
+    { name = "supervision" },
     { name = "trackpy" },
 ]
 
@@ -1337,6 +1338,7 @@ requires-dist = [
     { name = "motmetrics", specifier = ">=1.4.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "supervision", specifier = ">=0.21.0" },
     { name = "trackpy", specifier = ">=0.6.0" },
 ]
 


### PR DESCRIPTION
## Summary

Particle detection is solid enough now that tracking quality is the more useful thing to measure — but only trackpy's tracker had real MOTA/IDF1/fragmentation metrics behind it. ByteTrack has been production's other configured tracker in `particle-tracking/track.py` for a while, with zero shared implementation and zero benchmark evaluation of its own. This PR closes that gap: `verification/benchmark.py` gets a `--tracker {trackpy,bytetrack}` flag (default `trackpy`, unchanged behavior), `trackers-common` gets a shared `run_bytetrack` primitive both `track.py` and `benchmark.py` call, and `plot_benchmark.py` gets a bar-chart panel so both trackers' MOTA/IDF1/fragmentations show up side by side.

This explicitly reopens a scope decision the predecessor plan (`docs/plans/2026-08-05-001-fix-benchmark-tracking-linker-parity-plan.md`) deferred — "bytetrack linker parity stays out of scope... confirmed with the user before planning." That deferral was correct when the goal was closing a dependency gap for trackpy's own metrics; ByteTrack evaluation is the point of this one. Full plan: `docs/plans/2026-08-18-001-feat-bytetrack-tracking-support-plan.md`.

**Rebased on #45.** This branch was built on `main` before #45 (brightfield rendering + 4-way YOLOv12 benchmark tooling) merged. #45 landed first (older, more foundational, already green CI) and this branch was rebased on top, reconciling 6 overlapping files — most notably, #45 replaced the in-process MOTA/IDF1 accumulator-building step with a subprocess + `RLIMIT_AS`-isolated one; this PR's ByteTrack path now uses that same isolated builder instead of the unprotected version it originally shipped with, closing most of what would otherwise have been an accepted residual risk (see Review below).

## What changed

| Area | Change |
|---|---|
| `trackers-common` | New `bytetrack.py` (extracted verbatim from `track.py`'s inline loop, characterization-tested first); per-model tuning canonicalized in `tracker_defaults.yaml` |
| `detectors-common` | New `point_to_box.py` — deduplicates point→box synthesis that `detect_lodestar` and `detect_trackpy` each reimplemented independently |
| `particle-tracking` | `track.py` now calls the shared `run_bytetrack` instead of its own inline `sv.ByteTrack` loop (behavior-preserving) |
| `verification` | `benchmark.py` gains `--tracker`; `plot_benchmark.py` gains a grouped bar panel for MOTA/IDF1/fragmentations |

## Design decisions

- **ByteTrack's tuning is now genuinely per-model, not a single shared default.** All four detectors were independently swept (3×2×2 grid) against real data. rf-detr/yolo converge on `minimum_consecutive_frames=1`; lodestar/trackpy (noisier per-frame confidence) converge on `minimum_consecutive_frames=3` instead — a real, measured divergence, not noise (see "Real 4-way results" below). `track_activation_threshold` made no measured difference for any detector. Full per-model `tracker_configs.py` writer support for these values is still deferred (two independent doc-review passes flagged building it as premature until it's needed) — `benchmark.py` resolves them per-model through the canonical-defaults mechanism regardless, since it needs to either way.
- **Point-to-box synthesis lives in `detectors-common`, not `trackers-common`.** It's detection-side logic (consumes `box_size` before any tracker sees the result), matching the existing `box_size`/`nms_distance`/`tile_size` vs. `search_range`/`diameter`/`memory` split. No new cross-package dependency edge needed — `verification` already depends on `detectors-common` directly.
- **Output filenames get a one-time rename**: `tracking_metrics_{model_type}.csv` → `tracking_metrics_{model_type}_{tracker}.csv`, for both trackers, so results from either tracker coexist instead of overwriting each other. Verified no other in-repo consumer of the old name was missed.
- **ByteTrack's own tracking pass uses a lighter guard than trackpy's; the accumulator-building step downstream of it now shares trackpy's.** ByteTrack has no combinatorial subnet-blowup mode the way trackpy's exact linker does, so the tracking pass itself only needs a `signal.alarm` wall-clock timeout (which also now catches `MemoryError`, not just `TimeoutError`) — no pre-tracking density guard; see "Real 4-way results" below for why one was tried and removed. The *accumulator-building* step after tracking is the same code path #45 already hardened for trackpy (subprocess + `RLIMIT_AS`) — this PR's rebase retargets the ByteTrack path at that same isolated builder.

## Review

A 10-reviewer Tier 2 pass (correctness, testing, maintainability, project-standards, agent-native, learnings, performance, api-contract, reliability, adversarial) ran against the full diff. Real findings, fixed and verified against the test suite:

- **Correctness** — `plot_benchmark.py`'s bar hatch/alpha was keyed by a per-group index while the legend used a global tracker ordering, so a model with only one tracker present got a hatch that silently disagreed with the legend. Fixed with a shared index helper; added a regression test.
- **Performance** — the ByteTrack density guard fired only *after* the full (up to 90s) tracking pass completed. At this repo's default dataset density (~3.6x over the safe threshold), every default run was wasting that time before discarding the result. Added a cheap pre-check on raw density before calling into ByteTrack.
- **Reliability + adversarial (independently)** — the ByteTrack timeout wrapper only caught `TimeoutError`; a `MemoryError` from the in-process, non-isolated call would have crashed the whole process instead of degrading gracefully like every other failure path in this module. Now caught alongside the timeout.
- **API-contract** — the new canonical-defaults map's 3 ByteTrack keys were leaking into `tracker_configs.py`'s generated trackpy-only configs (which hardcode `tracker: "trackpy"`), contradicting this PR's own README claim. Scoped `tracker_configs.py` to a trackpy-only key subset.
- **Project-standards** — two stale comments/README claims that this PR's own changes had already contradicted, corrected.

One suggested fix (moving a function-local import to module scope, for import-convention consistency) was tried and reverted after confirming it broke 5 tests — the function-local import turned out to be load-bearing for a `mock.patch.object` test-mocking pattern. The rebase onto #45 also surfaced one more genuine bug the same way: `write_yolo_config` (new in #45) still referenced a name this branch's own review fix had removed from the shared import line — a `NameError`, caught by running the full suite post-rebase rather than trusting a clean merge.

**Known, accepted residual risks** (not fixed here, deliberately):
- ByteTrack's own tracking pass (as opposed to the now-isolated accumulator-building step after it) still runs in-process with only a wall-clock timeout, not full subprocess/memory isolation — a larger architectural change than this PR's scope.
- `--tracker` has no `config.yaml`-level default/override, unlike `--model-type` — a real parity gap, non-blocking.

## Testing

802 tests passing across all four touched packages (`detectors-common`, `trackers-common`, `particle-tracking`, `verification`), including new coverage for every fix above. `particle-tracking/track.py`'s ByteTrack extraction was characterization-tested against its pre-extraction behavior first (no existing config in this repo actually sets `tracker: bytetrack`, so a real-config before/after diff wasn't possible — the characterization tests are the equivalent proof). `--model-type yolo --tracker bytetrack` (only testable after rebasing onto #45's YOLOv12 support) verified end-to-end: canonical tuning resolves correctly and a full detect→track→MOTA/IDF1 run produces real metrics. No manual UI testing applicable (CLI/library tool).

## Real 4-way results, and two methodology bugs a real run caught

Ran the actual benchmark (not just the test suite) against the real dataset (`continuous_force_1500_5.0.lammpstrj`, 151 frames, ~1446 particles/frame, ~11px nearest-neighbor spacing) for all 4 detectors × both trackers. This surfaced two real bugs the test suite couldn't have caught, both fixed before these are the final numbers:

1. **Density pre-check was silently skipping ByteTrack on every real run.** A guard added during the Tier 2 review (skip ByteTrack above 400 detections/frame) was copied from trackpy's own accumulator-protection threshold without validating it against ByteTrack's actual cost. Every detector's real density (928-1258/frame) sits above 400, so the guard fired every time. Measured `run_bytetrack` directly against real data: ~18s for 151 frames at 1167/frame, nowhere near the 90s timeout. Removed the guard.
2. **Accuracy and tracking metrics used two unrelated correctness thresholds.** precision/recall/F1 matched within a hardcoded `10px`; MOTA/IDF1 matched within `2.5px` (`0.5 × psf_sigma`) — at ~11px particle spacing, a 10px accuracy radius risks crediting the wrong nearby particle, and a detection could pass accuracy while failing tracking's stricter identity match purely from normal localization jitter. Derived `match_distance` from the same `psf_sigma`-based formula tracking already uses; an explicit config override still wins.

Also gave ByteTrack a measured tuning pass instead of carrying forward unmeasured defaults: swept `lost_track_buffer`/`minimum_consecutive_frames`/`track_activation_threshold` against all four detectors' real detections independently. rf-detr and yolo converged on the identical optimum (`30, 1, 0.3` vs. the prior unmeasured `60, 1, 0.1`) — shorter track-buffer tolerance and a higher activation threshold both reduce identity confusion in this crowded scene. lodestar and trackpy instead converged on `minimum_consecutive_frames=3`, not `1` — the opposite of rf-detr/yolo's optimum, consistent with both being noisier detectors (lodestar's own F1~0.10; trackpy is a classical brightness threshold with no learned confidence) where filtering 3 consecutive frames before confirming a track pays off more than it costs in confirmation lag. Applied rf-detr's tuning to production `particle-tracking/config.yaml` too (rf-detr is the production default model), since this density is representative of real usage, not a synthetic stress test.

**Final numbers:**

| Model | Precision | Recall | F1 | Mean err (px) |
|---|---|---|---|---|
| rf-detr | 0.784 | 0.503 | 0.613 | 1.06 |
| yolo | 0.696 | 0.562 | 0.622 | 1.15 |
| trackpy | 0.583 | 0.465 | 0.517 | 0.74 |
| lodestar | 0.107 | 0.093 | 0.100 | 1.62 |

| Model | Tracker | MOTA | IDF1 | Fragmentations | ID switches |
|---|---|---|---|---|---|
| rf-detr | trackpy | 0.019 | 0.034 | 228 | 0 |
| rf-detr | **bytetrack** | **0.400** | **0.389** | 6652 | 3504 |
| yolo | trackpy | 0.282 | 0.247 | 11346 | 13807 |
| yolo | **bytetrack** | **0.371** | **0.354** | 6473 | 3623 |
| trackpy | trackpy | 0.147 | 0.338 | 6741 | 2764 |
| trackpy | **bytetrack** | **0.165** | **0.315** | 6572 | 5335 |
| lodestar | trackpy | -0.338 | 0.029 | 3510 | 2356 |
| lodestar | bytetrack | -0.566 | 0.035 | 9926 | 6891 |

ByteTrack beats trackpy's MOTA/IDF1 for rf-detr and yolo, edges it out on MOTA for the classical trackpy detector (IDF1 is close either way), and is worse for lodestar (already the weakest detector, and now visibly so — see below). Every value in this table is independently tuned per detector, not a shared guess — see the tuning paragraph above and `tracker_defaults.yaml`'s header comment for the full sweep.

**lodestar's F1 collapsed from 0.38 to 0.10 under the corrected threshold** — not a bug. Its own mean position error (1.6-5.6px) exceeds the new 2.5px radius by a wide margin; the old 10px accuracy threshold was masking a real localization weakness, not a detection-count weakness.

## Post-Deploy Monitoring & Validation

No production/runtime deployment — this is an offline research/benchmarking tool with no server component. Validated above with real runs, not just the test suite: all 8 `tracking_metrics_*.csv` combinations exist with non-zero, non-NaN MOTA/IDF1, and `benchmark_comparison.png`/`benchmark_summary.png` render correctly with both trackers visible.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Sonnet_5-D97757?logo=claude&logoColor=white)